### PR TITLE
allow newer versions of `cgmath` and `nalgebra`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["delaunay", "triangulation", "rtree", "geometry", "interpolation"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-cgmath = ">=0.10.0, <=0.12.0"
-nalgebra = ">=0.11.0, <=0.11.*"
+cgmath = ">=0.10.0, <=0.14.*"
+nalgebra = ">=0.11.0, <=0.12.*"
 num = "0.1.*"
 clamp = "0.1.*"
 smallvec = "0.3.*"


### PR DESCRIPTION
There are current releases of `cgmath` and `nalgebra` that facilitate working together with the rust language server. I've upgraded the versions because there is no breaking change. All tests are green so I think this change is okay.