### PR TITLE
Make CdtEdge public

### DIFF
--- a/src/delaunay/mod.rs
+++ b/src/delaunay/mod.rs
@@ -16,7 +16,7 @@ mod line_intersection_iterator;
 mod delaunay_basic;
 
 pub use self::delaunay2d::*;
-pub use self::cdt::{ConstrainedDelaunayTriangulation, FloatCDT};
+pub use self::cdt::{ConstrainedDelaunayTriangulation, FloatCDT, CdtEdge};
 pub use self::dcel::{FixedVertexHandle, FixedEdgeHandle, FixedFaceHandle,
                      VertexHandle, EdgeHandle, FaceHandle,
                      CCWIterator, ONextIterator};


### PR DESCRIPTION
Hi, so currently `VertexHandle<V, CdtEdge>`, `EdgeHandle<V, CdtEdge>` and `FaceHandle<V, CdtEdge>` cannot be used explicity (I.E. as return types, function parameters etc) because `CdtEdge` is private. As far as I'm aware, no major problems arise from making it public, so thats what I suggest.