### PR TITLE
Make DelauneyTriangulation Send+Sync

### DIFF
--- a/examples/delaunay_analysis.rs
+++ b/examples/delaunay_analysis.rs
@@ -94,7 +94,7 @@ fn main() {
         random_points_with_seed_range_and_origin::<f64>(20.0, Point2::new(1e10, -1e10), SIZE, seed);
     let vertices_i64_uniform = random_points_in_range::<i64>(10000, SIZE, seed);
 
-    let mut benches: Vec<Box<Benchmark>> = vec![
+    let mut benches: Vec<Box<dyn Benchmark>> = vec![
         // F64 Benchmarks
         Box::new(BenchSetup {
             title: "f64T - uniform - tree lookup",

--- a/src/delaunay/cdt.rs
+++ b/src/delaunay/cdt.rs
@@ -95,7 +95,7 @@ where
     locate_structure: L,
     all_points_on_line: bool,
     num_constraints: usize,
-    __kernel: PhantomData<*const K>,
+    __kernel: PhantomData<fn() -> K>,
 }
 
 #[derive(Debug)]

--- a/src/delaunay/cdt.rs
+++ b/src/delaunay/cdt.rs
@@ -1046,4 +1046,11 @@ mod test {
         let parsed: FloatCDT<[f32; 2], DelaunayWalkLocate> = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.num_vertices(), 1);
     }
+
+    #[test]
+    fn test_send_sync_impl() {
+        fn send_sync_tester<T: Send+Sync>(_: &T) {}
+        let cdt = CDT::new();
+        send_sync_tester(&cdt);
+    }
 }


### PR DESCRIPTION
The PR makes the following changes:
+ change to `PhantomData<fn() -> K>` for storing Kernels
+ added compile-time tests to verify common variants are
  `Send+Sync`
+ fix minor lints

In addition, we may also tweak / duplicate the existing `test_nearest_neighbor` using `crossbeam` to test run-time multi-threaded behavior.   Pls. let me know if that makes sense, and I can add that functionality to this PR

closes #42 