### PR TITLE
Benchmarks:  Delaunay Insert and Locate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0", optional=true, features=["rc", "serde_derive"] }
 rand = "0.5.*"
 serde_json = "1.0"
 approx = "0.2.*"
+criterion = "0.2"
 
 [dev-dependencies.cgmath]
 version = "<=0.17.*"
@@ -38,3 +39,7 @@ debug-assertions = false
 
 [badges]
 maintenance = { status = "passively-maintained" }
+
+[[bench]]
+name = "delaunay"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,138 @@
+# Running Benchmarks
+
+We use `criterion` crate for performing benchmarks.
+Benchmarks can be run via `cargo bench`. To run a specific
+set of benchmarks:
+
+```
+cargo bench --bench delaunay -- <filter>
+```
+
+For instance `f64` to run only floating-point tests, or
+`i64` for only integer tests.
+
+# Delaunay Benchmarks
+
+We run the benchmarks on all the available kernel,
+locate-strategy combinations, and at varying sizes.
+
+## Insertion
+
+We benchmark the time taken to insert n random values, where
+n quadruples from 1 to 16384 (8 data points in total).
+
+### Float Kernels
+
+```
+insert/uniform_f64/float_kernel/tree_locate/1           1.00   247.7±34.48ns        ? B/sec
+insert/uniform_f64/float_kernel/tree_locate/4           1.00  1359.9±43.54ns        ? B/sec
+insert/uniform_f64/float_kernel/tree_locate/16          1.00     10.4±0.25µs        ? B/sec
+insert/uniform_f64/float_kernel/tree_locate/64          1.00     73.5±0.84µs        ? B/sec
+insert/uniform_f64/float_kernel/tree_locate/256         1.00    402.8±1.16µs        ? B/sec
+insert/uniform_f64/float_kernel/tree_locate/1024        1.00      2.0±0.01ms        ? B/sec
+insert/uniform_f64/float_kernel/tree_locate/4096        1.00      9.3±0.07ms        ? B/sec
+insert/uniform_f64/float_kernel/tree_locate/16384       1.00     43.3±0.56ms        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/1           1.00    116.7±1.10ns        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/4           1.00   982.8±14.96ns        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/16          1.00      4.9±0.26µs        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/64          1.00     22.8±0.61µs        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/256         1.00    171.0±0.62µs        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/1024        1.00   1084.2±1.40µs        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/4096        1.00     10.3±0.03ms        ? B/sec
+insert/uniform_f64/float_kernel/walk_locate/16384       1.00     91.8±0.44ms        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/1         1.00   290.5±26.25ns        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/4         1.00  1348.2±50.04ns        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/16        1.00     10.1±0.22µs        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/64        1.00     68.3±1.07µs        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/256       1.00    374.8±1.14µs        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/1024      1.00   1891.8±7.48µs        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/4096      1.00      8.8±0.08ms        ? B/sec
+insert/uniform_f64/trivial_kernel/tree_locate/16384     1.00     41.0±0.58ms        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/1         1.00    115.5±0.84ns        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/4         1.00   967.5±17.72ns        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/16        1.00      4.5±0.30µs        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/64        1.00     19.1±0.80µs        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/256       1.00    123.0±0.73µs        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/1024      1.00    802.2±3.29µs        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/4096      1.00      7.8±0.04ms        ? B/sec
+insert/uniform_f64/trivial_kernel/walk_locate/16384     1.00     73.3±0.58ms        ? B/sec
+```
+
+
+### Integer Kernels
+
+```
+insert/uniform_i64/adaptive_kernel/tree_locate/1        1.00   264.8±35.94ns        ? B/sec
+insert/uniform_i64/adaptive_kernel/tree_locate/4        1.00      2.5±0.37µs        ? B/sec
+insert/uniform_i64/adaptive_kernel/tree_locate/16       1.00     63.4±5.57µs        ? B/sec
+insert/uniform_i64/adaptive_kernel/tree_locate/64       1.00   470.6±22.35µs        ? B/sec
+insert/uniform_i64/adaptive_kernel/tree_locate/256      1.00      2.4±0.05ms        ? B/sec
+insert/uniform_i64/adaptive_kernel/tree_locate/1024     1.00     10.8±0.11ms        ? B/sec
+insert/uniform_i64/adaptive_kernel/tree_locate/4096     1.00     46.2±0.34ms        ? B/sec
+insert/uniform_i64/adaptive_kernel/tree_locate/16384    1.00    196.4±1.26ms        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/1        1.00    114.2±1.02ns        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/4        1.00      2.2±0.46µs        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/16       1.00     54.7±4.88µs        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/64       1.00   394.6±14.43µs        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/256      1.00      2.0±0.03ms        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/1024     1.00      9.2±0.08ms        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/4096     1.00     42.9±0.25ms        ? B/sec
+insert/uniform_i64/adaptive_kernel/walk_locate/16384    1.00    217.8±0.93ms        ? B/sec
+insert/uniform_i64/trivial_kernel/tree_locate/1         1.00   305.3±32.50ns        ? B/sec
+insert/uniform_i64/trivial_kernel/tree_locate/4         1.00  1381.6±57.60ns        ? B/sec
+insert/uniform_i64/trivial_kernel/walk_locate/1         1.00     81.0±1.87ns        ? B/sec
+insert/uniform_i64/trivial_kernel/walk_locate/4         1.00   743.0±23.15ns        ? B/sec
+```
+
+## Locate Queries
+
+We benchmark the time taken to locate a random point, given
+a tree with n random points. Again, n quadruples from 1 to
+16384 (8 data points in total).
+
+### Float Kernels
+
+```
+locate/uniform_f64/float_kernel/tree_locate/1           1.00    513.1±0.67ns        ? B/sec
+locate/uniform_f64/float_kernel/tree_locate/4           1.00    585.4±0.49ns        ? B/sec
+locate/uniform_f64/float_kernel/tree_locate/16          1.00    642.2±0.61ns        ? B/sec
+locate/uniform_f64/float_kernel/tree_locate/64          1.00    690.5±0.71ns        ? B/sec
+locate/uniform_f64/float_kernel/tree_locate/256         1.00    763.1±0.60ns        ? B/sec
+locate/uniform_f64/float_kernel/tree_locate/1024        1.00    850.2±2.35ns        ? B/sec
+locate/uniform_f64/float_kernel/tree_locate/4096        1.00    975.9±3.17ns        ? B/sec
+locate/uniform_f64/float_kernel/tree_locate/16384       1.00   1154.4±4.17ns        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/1           1.00    514.2±0.27ns        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/4           1.00    569.6±0.57ns        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/16          1.00    629.0±0.39ns        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/64          1.00    811.2±0.66ns        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/256         1.00    841.4±0.56ns        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/1024        1.00   1010.0±1.12ns        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/4096        1.00      3.0±0.00µs        ? B/sec
+locate/uniform_f64/float_kernel/walk_locate/16384       1.00      3.8±0.01µs        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/1         1.00    512.6±0.40ns        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/4         1.00    580.9±0.49ns        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/16        1.00    637.1±2.80ns        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/64        1.00    681.5±1.24ns        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/256       1.00    736.6±1.32ns        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/1024      1.00    816.9±2.19ns        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/4096      1.00    937.1±6.65ns        ? B/sec
+locate/uniform_f64/trivial_kernel/tree_locate/16384     1.00   1136.4±1.70ns        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/1         1.00    509.4±0.43ns        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/4         1.00    561.4±0.90ns        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/16        1.00    592.4±0.33ns        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/64        1.00    704.7±0.22ns        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/256       1.00    723.9±0.31ns        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/1024      1.00    843.0±0.74ns        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/4096      1.00      2.3±0.00µs        ? B/sec
+locate/uniform_f64/trivial_kernel/walk_locate/16384     1.00      3.1±0.01µs        ? B/sec
+```
+
+### Integer Kernels
+
+```
+locate/uniform_i64/adaptive_kernel/tree_locate/1        1.00    509.7±0.36ns        ? B/sec
+locate/uniform_i64/adaptive_kernel/tree_locate/4        1.00    588.9±0.47ns        ? B/sec
+locate/uniform_i64/adaptive_kernel/walk_locate/1        1.00    505.0±1.25ns        ? B/sec
+locate/uniform_i64/adaptive_kernel/walk_locate/4        1.00    548.2±0.31ns        ? B/sec
+locate/uniform_i64/trivial_kernel/walk_locate/1         1.00    510.2±0.30ns        ? B/sec
+```

--- a/benches/delaunay.rs
+++ b/benches/delaunay.rs
@@ -1,0 +1,71 @@
+use criterion::*;
+use spade::{
+    delaunay::*,
+    kernels::*,
+    rtree::*,
+};
+use rand::*;
+
+const SEED: &'static [u8; 16] = b"rand::thread_rng";
+
+fn insertion_benchmarks(c: &mut Criterion) {
+    // Setup iteration parameters
+    const MAX_SIZE: usize = 15;
+    let sizes = (0..MAX_SIZE).step_by(2).map(|s| 1 << s);
+
+    macro_rules! insert_block {
+        ($e: expr, $data: expr) => {
+            move |b, param| {
+                let mut rng = XorShiftRng::from_seed(*SEED);
+                let data = ($data)(*param, &mut rng);
+                b.iter_with_large_drop(|| {
+                    let mut t = $e;
+                    for d in &data { t.insert(*d); }
+                    t
+                })
+            }
+        }
+    }
+    c.bench("insert", benchmark_kernels!(sizes, insert_block));
+}
+
+fn locate_benchmarks(c: &mut Criterion) {
+    // Setup iteration parameters
+    const MAX_SIZE: usize = 15;
+    let sizes = (0..MAX_SIZE).step_by(2).map(|s| 1 << s);
+
+    macro_rules! locate_block {
+        ($e: expr, $data: expr) => {
+            move |b, param| {
+                let mut rng = XorShiftRng::from_seed(*SEED);
+
+                // Create datastructure to test queries on
+                let t = {
+                    let mut t = $e;
+                    let data = ($data)(*param, &mut rng);
+                    for d in data { t.insert(d); }
+                    t
+                };
+
+                use cgmath::Point2;
+                b.iter_with_setup(
+                    || { Point2::new(rng.gen(), rng.gen()) },
+                    |pt| { t.locate(&pt); }
+                );
+
+            }
+        }
+    }
+    c.bench("locate", benchmark_kernels!(sizes, locate_block));
+
+}
+
+criterion_group!{
+    name = benches;
+    config = Criterion::default().sample_size(25);
+    targets = insertion_benchmarks, locate_benchmarks
+}
+criterion_main!(benches);
+
+mod harness;
+use harness::*;

--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -1,0 +1,69 @@
+//! Benchmark harness and related utilities
+
+use cgmath::*;
+use rand::*;
+use spade::*;
+use rand::distributions::range::SampleRange;
+use rand::distributions::{Distribution, Range};
+
+pub fn uniform_points_in_range<S: SpadeNum + SampleRange + BaseNum, R: Rng>(
+    range: S, size: usize, rng: &mut R,
+) -> Vec<Point2<S>> {
+
+    let range = Range::new(-range.clone(), range.clone());
+
+    (0..size)
+        .map(|_| Point2::new(range.sample(rng), range.sample(rng)))
+        .collect()
+
+}
+
+
+pub fn uniform_i64s<R: Rng>(size: usize, rng: &mut R) -> Vec<Point2<i64>>{
+    uniform_points_in_range(1 << 10, size, rng)
+}
+
+pub fn uniform_f64s<R: Rng>(size: usize, rng: &mut R) -> Vec<Point2<f64>>{
+    uniform_points_in_range(f64::one(), size, rng)
+}
+
+#[macro_export]
+macro_rules! delaunay {
+    ($k: ty, $l: ty) => {
+        spade::delaunay::DelaunayTriangulation::<_, $k, $l>::new()
+    }
+}
+
+#[macro_export]
+macro_rules! benchmark_kernels {
+    ($s: expr, $mac: ident) => {
+        ParameterizedBenchmark::new(
+            "uniform_f64/float_kernel/tree_locate",
+            $mac!(delaunay!(FloatKernel, RTree<_>), uniform_f64s),
+            $s
+        ).with_function(
+            "uniform_f64/float_kernel/walk_locate",
+            $mac!(delaunay!(FloatKernel, DelaunayWalkLocate), uniform_f64s),
+        ).with_function(
+            "uniform_f64/trivial_kernel/tree_locate",
+            $mac!(delaunay!(TrivialKernel, RTree<_>), uniform_f64s),
+        ).with_function(
+            "uniform_f64/trivial_kernel/walk_locate",
+            $mac!(delaunay!(TrivialKernel, DelaunayWalkLocate), uniform_f64s),
+        )
+        // .with_function(
+        //     "uniform_i64/adaptive_kernel/tree_locate",
+        //     $mac!(delaunay!(AdaptiveIntKernel, RTree<_>), uniform_i64s),
+        // ).with_function(
+        //     "uniform_i64/adaptive_kernel/walk_locate",
+        //     $mac!(delaunay!(AdaptiveIntKernel, DelaunayWalkLocate), uniform_i64s),
+        // ).with_function(
+        //     "uniform_i64/trivial_kernel/tree_locate",
+        //     $mac!(delaunay!(TrivialKernel, RTree<_>), uniform_i64s),
+        // ).with_function(
+        //     "uniform_i64/trivial_kernel/walk_locate",
+        //     $mac!(delaunay!(TrivialKernel, DelaunayWalkLocate), uniform_i64s),
+        // )
+
+    }
+}


### PR DESCRIPTION
I've added simple insert and locate benchmarks via `criterion` crate on all the Delaunay kernels, and locate strats.   Criterion seems to be fairly well-used, and maintained and recommended in many blogs.  It also seems fairly flexible and easy to use.  The float kernels work quite well, and you can see the stats in `benches/README.md`.    

Unfortunately, with `i64`, some of the benchmarks seem to just hang (but with 100% cpu usage).  Criterion thinks it is warming for 3 seconds, but it shows no progress for more than 20 minutes on my machine.   The specific combinations that seem to be problematic are:

1. Inserting elements with `<i64, TrivialKernel, *>`
1. Locating elements (after inserting) wth `<i64, *, *>`

You can try out all `i64` benches by typing: `cargo bench --bench delaunay -- i64`.  Please see `benches/README.md` for the statistics I'm able to collect.  Once we identify the issue here, I should be able to add benches for interpolation too.