### PR TITLE
Fix bug for recursive item removal

### DIFF
--- a/src/delaunay/dcel.rs
+++ b/src/delaunay/dcel.rs
@@ -202,7 +202,7 @@ where
     }
 
     pub fn fixed_vertices(&self) -> FixedVerticesIterator {
-        (0..self.num_vertices())
+        0..self.num_vertices()
     }
 
     pub fn faces(&self) -> FacesIterator<V, E> {


### PR DESCRIPTION
* Recompute MBR recursively whenever an item is removed from an inner
  node.
* Add test case to verify new fix.
* Apply cosmetic change to remove compiler warning.

This PR fixes issue #54 