### PR TITLE
can_add_constraint_edge sense inversed

### DIFF
--- a/src/cdt.rs
+++ b/src/cdt.rs
@@ -260,7 +260,7 @@ where
     /// constraint edge.
     pub fn can_add_constraint(&self, from: FixedVertexHandle, to: FixedVertexHandle) -> bool {
         let line_intersection_iterator = LineIntersectionIterator::new_from_handles(self, from, to);
-        self.contains_any_constraint_edge(line_intersection_iterator)
+        !self.contains_any_constraint_edge(line_intersection_iterator)
     }
 
     /// Checks if a line intersects a constraint edge.


### PR DESCRIPTION
It currently returns self.contains_any_constraint_edge(lineIntersectionIterator), which is true when the line intersects a constraint edge. In which case, one *cannot* add a constraint edge.