### PR TITLE
chore: remove optional crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ optional = true
 version = "1"
 features = ["derive"]
 
-[features]
-serde = ["dep:serde"]
-
 [workspace]
 members = ["delaunay_compare"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ bench = false
 smallvec = "1"
 robust = "0.2"
 num-traits = "0.2"
-optional = "0.5"
 
 [dependencies.serde]
 package = "serde"
@@ -25,7 +24,7 @@ version = "1"
 features = ["derive"]
 
 [features]
-serde = ["optional/serde", "dep:serde"]
+serde = ["dep:serde"]
 
 [workspace]
 members = ["delaunay_compare"]

--- a/src/delaunay_core/bulk_load.rs
+++ b/src/delaunay_core/bulk_load.rs
@@ -478,7 +478,6 @@ impl Hull {
             .find(|(index, _)| !self.empty.contains(index))
             .unwrap();
 
-        let first_index = first_index;
         let mut current_index = first_index;
         let first_bucket = self.ceiled_bucket(current_node.angle);
         self.buckets[first_bucket] = current_index;

--- a/src/delaunay_core/dcel.rs
+++ b/src/delaunay_core/dcel.rs
@@ -1,7 +1,6 @@
 use super::handles::handle_defs::FixedHandleImpl;
 use super::handles::iterators::*;
 use super::handles::*;
-use optional::Optioned;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -21,7 +20,7 @@ impl<DE, UE> EdgeData<DE, UE> {}
     serde(crate = "serde")
 )]
 pub(super) struct FaceEntry<F> {
-    pub(super) adjacent_edge: Optioned<FixedDirectedEdgeHandle>,
+    pub(super) adjacent_edge: Option<FixedDirectedEdgeHandle>,
     pub(super) data: F,
 }
 
@@ -33,7 +32,7 @@ pub(super) struct FaceEntry<F> {
 )]
 pub(super) struct VertexEntry<V> {
     pub(super) data: V,
-    pub(super) out_edge: Optioned<FixedDirectedEdgeHandle>,
+    pub(super) out_edge: Option<FixedDirectedEdgeHandle>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -247,7 +246,7 @@ impl<V, DE, UE, F> Dcel<V, DE, UE, F> {
         &self,
         handle: FixedHandleImpl<FaceTag, InnerOuter>,
     ) -> Option<FixedHandleImpl<DirectedEdgeTag, InnerTag>> {
-        self.faces[handle.index()].adjacent_edge.into_option()
+        self.faces[handle.index()].adjacent_edge
     }
 
     pub fn vertex_data<InnerOuter: InnerOuterMarker>(

--- a/src/delaunay_core/dcel_operations.rs
+++ b/src/delaunay_core/dcel_operations.rs
@@ -49,8 +49,8 @@ where
 
         dcel.half_edge_mut(edge).face = OUTER_FACE_HANDLE;
 
-        dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = optional::some(edge);
-        dcel.vertices[from.index()].out_edge = optional::some(edge);
+        dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = Some(edge);
+        dcel.vertices[from.index()].out_edge = Some(edge);
     }
 
     IsolateVertexResult {
@@ -144,7 +144,7 @@ where
         let new_edge = EdgeEntry::new(new_norm, new_twin);
 
         let new_face = FaceEntry {
-            adjacent_edge: optional::some(new_edge_handle),
+            adjacent_edge: Some(new_edge_handle),
             data: F::default(),
         };
 
@@ -157,7 +157,7 @@ where
         dcel.half_edge_mut(inner_edge).next = outer_edge;
         dcel.half_edge_mut(inner_edge).face = new_face_handle;
 
-        dcel.vertices[outer_edge_from.index()].out_edge = optional::some(outer_edge);
+        dcel.vertices[outer_edge_from.index()].out_edge = Some(outer_edge);
 
         dcel.edges.push(new_edge);
         new_edges.push(new_edge_handle.as_undirected());
@@ -174,7 +174,7 @@ where
     // Create a new face for the last triangle
     let new_face_handle = FixedFaceHandle::new(dcel.faces.len());
     let new_face = FaceEntry {
-        adjacent_edge: optional::some(inner_edge),
+        adjacent_edge: Some(inner_edge),
         data: F::default(),
     };
     dcel.half_edge_mut(inner_edge).face = new_face_handle;
@@ -194,13 +194,13 @@ where
 
     // Update out_edge entries for the triangle's vertices
     let prev_origin = dcel.half_edge_mut(inner_edge_prev).origin;
-    dcel.vertices[prev_origin.index()].out_edge = optional::some(inner_edge_prev);
+    dcel.vertices[prev_origin.index()].out_edge = Some(inner_edge_prev);
 
     let next_origin = dcel.half_edge_mut(inner_edge_next).origin;
-    dcel.vertices[next_origin.index()].out_edge = optional::some(inner_edge_next);
+    dcel.vertices[next_origin.index()].out_edge = Some(inner_edge_next);
 
     // fan_origin is the third vertex of the triangle
-    dcel.vertices[fan_origin.index()].out_edge = optional::some(inner_edge);
+    dcel.vertices[fan_origin.index()].out_edge = Some(inner_edge);
 
     IsolateVertexResult {
         new_edges,
@@ -281,11 +281,11 @@ where
     dcel.half_edge_mut(edge).face = new_face_handle;
     dcel.half_edge_mut(edge_entry.next).face = new_face_handle;
 
-    dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = optional::some(new_outer_handle);
+    dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = Some(new_outer_handle);
 
     dcel.edges.push(new_edge_entry);
     dcel.faces.push(FaceEntry {
-        adjacent_edge: optional::some(new_inner_handle),
+        adjacent_edge: Some(new_inner_handle),
         data: F::default(),
     });
 
@@ -368,13 +368,13 @@ where
     });
 
     dcel.faces.push(FaceEntry {
-        adjacent_edge: optional::some(edge),
+        adjacent_edge: Some(edge),
         data: F::default(),
     });
 
     dcel.vertices.push(VertexEntry {
         data: new_vertex,
-        out_edge: optional::some(new_prev_handle.normalized()),
+        out_edge: Some(new_prev_handle.normalized()),
     });
 
     *dcel.half_edge_mut(edge) = HalfEdgeEntry {
@@ -384,8 +384,7 @@ where
         ..edge_entry
     };
 
-    dcel.faces[edge_entry.face.index()].adjacent_edge =
-        optional::some(new_prev_handle.not_normalized());
+    dcel.faces[edge_entry.face.index()].adjacent_edge = Some(new_prev_handle.not_normalized());
 
     dcel.half_edge_mut(edge_entry.next).prev = new_next_handle.not_normalized();
     dcel.half_edge_mut(edge_entry.prev).next = new_prev_handle.not_normalized();
@@ -449,7 +448,7 @@ where
 
     dcel.vertices.push(VertexEntry {
         data: new_vertex,
-        out_edge: optional::some(new_edge),
+        out_edge: Some(new_edge),
     });
 
     new_vertex_handle
@@ -496,7 +495,7 @@ where
 
     dcel.half_edge_mut(rev).origin = new_vertex_handle;
 
-    dcel.vertices[to.index()].out_edge = optional::some(new_edge_rev);
+    dcel.vertices[to.index()].out_edge = Some(new_edge_rev);
 
     let (new_edge_next, new_rev_prev) = if is_isolated {
         (new_edge_rev, new_edge)
@@ -523,7 +522,7 @@ where
 
     dcel.vertices.push(VertexEntry {
         data: new_vertex,
-        out_edge: optional::some(new_edge),
+        out_edge: Some(new_edge),
     });
 
     new_vertex_handle
@@ -629,13 +628,13 @@ where
     };
 
     let new_face = FaceEntry {
-        adjacent_edge: optional::some(e2),
+        adjacent_edge: Some(e2),
         data: Default::default(),
     };
 
     let new_vertex_entry = VertexEntry {
         data: new_vertex_data,
-        out_edge: optional::some(e2),
+        out_edge: Some(e2),
     };
 
     dcel.edges.push(EdgeEntry::new(edge1, twin1));
@@ -654,8 +653,8 @@ where
     dcel.half_edge_mut(edge_next).face = nf;
     dcel.half_edge_mut(edge_twin).origin = nv;
 
-    dcel.vertices[to.index()].out_edge = optional::some(e2.rev());
-    dcel.faces[f1.index()].adjacent_edge = optional::some(edge_handle);
+    dcel.vertices[to.index()].out_edge = Some(e2.rev());
+    dcel.faces[f1.index()].adjacent_edge = Some(edge_handle);
 
     nv
 }
@@ -792,17 +791,17 @@ where
     };
 
     let new_vertex_entry = VertexEntry {
-        out_edge: optional::some(t0),
+        out_edge: Some(t0),
         data: new_vertex,
     };
 
     let face2 = FaceEntry {
-        adjacent_edge: optional::some(e2),
+        adjacent_edge: Some(e2),
         data: F::default(),
     };
 
     let face3 = FaceEntry {
-        adjacent_edge: optional::some(e3),
+        adjacent_edge: Some(e3),
         data: F::default(),
     };
 
@@ -824,10 +823,10 @@ where
     dcel.half_edge_mut(ep).prev = t3;
 
     dcel.vertices.push(new_vertex_entry);
-    dcel.vertices[v3.index()].out_edge = optional::some(e2);
+    dcel.vertices[v3.index()].out_edge = Some(e2);
 
-    dcel.faces[f0.index()].adjacent_edge = optional::some(e0);
-    dcel.faces[f1.index()].adjacent_edge = optional::some(e1);
+    dcel.faces[f0.index()].adjacent_edge = Some(e0);
+    dcel.faces[f1.index()].adjacent_edge = Some(e1);
     dcel.faces.push(face2);
     dcel.faces.push(face3);
 
@@ -841,7 +840,7 @@ pub fn insert_first_vertex<V, DE, UE, F>(
     assert!(dcel.vertices.is_empty());
     dcel.vertices.push(VertexEntry {
         data: vertex,
-        out_edge: optional::none(),
+        out_edge: None,
     });
     FixedVertexHandle::new(0)
 }
@@ -876,10 +875,10 @@ where
 
     dcel.vertices.push(VertexEntry {
         data: vertex,
-        out_edge: optional::some(not_normalized),
+        out_edge: Some(not_normalized),
     });
-    dcel.vertices[0].out_edge = optional::some(normalized);
-    dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = optional::some(normalized);
+    dcel.vertices[0].out_edge = Some(normalized);
+    dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = Some(normalized);
     second_vertex
 }
 
@@ -939,12 +938,12 @@ where
     let f2 = FixedFaceHandle::new(dcel.faces.len() + 1);
 
     let face1 = FaceEntry {
-        adjacent_edge: optional::some(e1),
+        adjacent_edge: Some(e1),
         data: F::default(),
     };
 
     let face2 = FaceEntry {
-        adjacent_edge: optional::some(e2),
+        adjacent_edge: Some(e2),
         data: F::default(),
     };
 
@@ -952,7 +951,7 @@ where
     dcel.faces.push(face2);
 
     let vertex = VertexEntry {
-        out_edge: optional::some(e4),
+        out_edge: Some(e4),
         data: vertex,
     };
     dcel.vertices.push(vertex);
@@ -1021,7 +1020,7 @@ where
     F: Default,
 {
     let outer_face = FaceEntry {
-        adjacent_edge: optional::none(),
+        adjacent_edge: None,
         data: F::default(),
     };
 
@@ -1066,11 +1065,11 @@ pub fn flip_cw<V, DE, UE, F>(dcel: &mut Dcel<V, DE, UE, F>, e: FixedUndirectedEd
     dcel.half_edge_mut(ep).prev = t;
     dcel.half_edge_mut(ep).face = t_face;
 
-    dcel.vertices[e_origin.index()].out_edge = optional::some(tn);
-    dcel.vertices[t_origin.index()].out_edge = optional::some(en);
+    dcel.vertices[e_origin.index()].out_edge = Some(tn);
+    dcel.vertices[t_origin.index()].out_edge = Some(en);
 
-    dcel.faces[e_face.index()].adjacent_edge = optional::some(e);
-    dcel.faces[t_face.index()].adjacent_edge = optional::some(t);
+    dcel.faces[e_face.index()].adjacent_edge = Some(e);
+    dcel.faces[t_face.index()].adjacent_edge = Some(t);
 }
 
 /// Vertex removal has two stages: First, the vertex is disconnected from its surroundings (isolated).
@@ -1135,8 +1134,8 @@ fn fix_handle_swap<V, DE, UE, F>(
 
     let edge_origin = dcel.half_edge(edge_handle).origin;
     let edge_face = dcel.half_edge(edge_handle).face;
-    dcel.vertices[edge_origin.index()].out_edge = optional::some(edge_handle);
-    dcel.faces[edge_face.index()].adjacent_edge = optional::some(edge_handle);
+    dcel.vertices[edge_origin.index()].out_edge = Some(edge_handle);
+    dcel.faces[edge_face.index()].adjacent_edge = Some(edge_handle);
 }
 
 /// Removes a vertex from the DCEL by swapping in another.
@@ -1233,8 +1232,8 @@ fn remove_when_two_vertices_left<V, DE, UE, F>(
     };
 
     let result = dcel.vertices.swap_remove(vertex_to_remove.index()).data;
-    dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = optional::none();
-    dcel.vertices[0].out_edge = optional::none();
+    dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = None;
+    dcel.vertices[0].out_edge = None;
     dcel.edges.clear();
     RemovalResult {
         removed_vertex: result,
@@ -1260,8 +1259,8 @@ fn remove_when_all_vertices_on_line<V, DE, UE, F>(
 
             dcel.half_edge_mut(o_next).prev = o_next.rev();
             dcel.half_edge_mut(o_next.rev()).next = o_next;
-            dcel.vertices[vertex_to_update.index()].out_edge = optional::some(o_next);
-            dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = optional::some(o_next);
+            dcel.vertices[vertex_to_update.index()].out_edge = Some(o_next);
+            dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = Some(o_next);
 
             swap_remove_undirected_edge(dcel, out_edge1.as_undirected());
 
@@ -1290,10 +1289,10 @@ fn remove_when_all_vertices_on_line<V, DE, UE, F>(
                 dcel.half_edge_mut(t1.rev()).prev = t2_prev;
             }
 
-            dcel.vertices[e2_to.index()].out_edge = optional::some(t1.rev());
+            dcel.vertices[e2_to.index()].out_edge = Some(t1.rev());
             dcel.half_edge_mut(t1.rev()).origin = e2_to;
 
-            dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = optional::some(t1);
+            dcel.faces[OUTER_FACE_HANDLE.index()].adjacent_edge = Some(t1);
 
             let result = swap_remove_vertex(dcel, vertex_to_remove);
             swap_remove_undirected_edge(dcel, e2.as_undirected());
@@ -1372,27 +1371,27 @@ mod test {
         );
 
         let face0 = FaceEntry {
-            adjacent_edge: optional::some(e0),
+            adjacent_edge: Some(e0),
             data: (),
         };
 
         let face1 = FaceEntry {
-            adjacent_edge: optional::some(e1),
+            adjacent_edge: Some(e1),
             data: (),
         };
 
         let vertex0 = VertexEntry {
-            out_edge: optional::some(e0),
+            out_edge: Some(e0),
             data: 0,
         };
 
         let vertex1 = VertexEntry {
-            out_edge: optional::some(e2),
+            out_edge: Some(e2),
             data: 1,
         };
 
         let vertex2 = VertexEntry {
-            out_edge: optional::some(e4),
+            out_edge: Some(e4),
             data: 2,
         };
 

--- a/src/delaunay_core/handles/handle_defs.rs
+++ b/src/delaunay_core/handles/handle_defs.rs
@@ -27,38 +27,6 @@ pub struct FixedHandleImpl<Type, InnerOuter: InnerOuterMarker> {
     inner_outer: InnerOuter,
 }
 
-impl<Type: Default, InnerOuter: InnerOuterMarker> optional::Noned
-    for FixedHandleImpl<Type, InnerOuter>
-{
-    fn is_none(&self) -> bool {
-        optional::wrap(self.index).is_none()
-    }
-
-    fn get_none() -> Self {
-        Self {
-            index: optional::Optioned::<_>::none().unpack(),
-            ty: Default::default(),
-            inner_outer: Default::default(),
-        }
-    }
-}
-
-impl<Type: Default, InnerOuter: InnerOuterMarker> optional::OptEq
-    for FixedHandleImpl<Type, InnerOuter>
-{
-    fn opt_eq(&self, other: &Self) -> bool {
-        self.index().opt_eq(&other.index())
-    }
-}
-
-impl<Type: Default, InnerOuter: InnerOuterMarker> optional::OptOrd
-    for FixedHandleImpl<Type, InnerOuter>
-{
-    fn opt_cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.index().opt_cmp(&other.index())
-    }
-}
-
 impl<Type, InnerOuter: InnerOuterMarker> std::fmt::Debug for FixedHandleImpl<Type, InnerOuter> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FixedHandle")
@@ -231,20 +199,5 @@ impl DelaunayElementType for DirectedVoronoiEdgeTag {
 impl DelaunayElementType for UndirectedVoronoiEdgeTag {
     fn num_elements<V, DE, UE, F>(dcel: &Dcel<V, DE, UE, F>) -> usize {
         dcel.num_undirected_edges()
-    }
-}
-
-#[cfg(test)]
-pub mod test {
-    use optional::Optioned;
-
-    use crate::handles::FixedDirectedEdgeHandle;
-
-    #[test]
-    fn optioned_handle_is_smaller_than_option_type() {
-        let optioned_size = std::mem::size_of::<Optioned<FixedDirectedEdgeHandle>>();
-        let option_size = std::mem::size_of::<Option<FixedDirectedEdgeHandle>>();
-
-        assert!(optioned_size < option_size);
     }
 }

--- a/src/delaunay_core/handles/handle_impls.rs
+++ b/src/delaunay_core/handles/handle_impls.rs
@@ -111,10 +111,7 @@ impl<'a, V, DE, UE, F, Type: Copy, InnerOuter: InnerOuterMarker> Clone
     for DynamicHandleImpl<'a, V, DE, UE, F, Type, InnerOuter>
 {
     fn clone(&self) -> Self {
-        Self {
-            dcel: self.dcel,
-            handle: self.handle,
-        }
+        *self
     }
 }
 

--- a/src/delaunay_core/handles/iterators/fixed_iterators.rs
+++ b/src/delaunay_core/handles/iterators/fixed_iterators.rs
@@ -71,7 +71,7 @@ where
         DynamicHandleIterator {
             fixed_iterator: FixedHandleIterator::new(Type::num_elements(dcel)),
             dcel,
-            inner_outer: std::marker::PhantomData::default(),
+            inner_outer: std::marker::PhantomData,
         }
     }
 }

--- a/src/delaunay_triangulation.rs
+++ b/src/delaunay_triangulation.rs
@@ -356,7 +356,7 @@ mod test {
     use crate::{DelaunayTriangulation, InsertionError, Point2, Triangulation};
 
     #[allow(unused)]
-    #[cfg(all(feature = "serde"))]
+    #[cfg(feature = "serde")]
     // Just needs to compile
     fn check_serde() {
         use serde::{Deserialize, Serialize};

--- a/src/intersection_iterator.rs
+++ b/src/intersection_iterator.rs
@@ -60,12 +60,7 @@ where
     V: HasPosition,
 {
     fn clone(&self) -> Self {
-        use self::Intersection::*;
-        match self {
-            EdgeIntersection(handle) => EdgeIntersection(*handle),
-            VertexIntersection(handle) => VertexIntersection(*handle),
-            EdgeOverlap(handle) => EdgeOverlap(*handle),
-        }
+        *self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! * Serde support with the `serde` feature.
 
 #![forbid(unsafe_code)]
+#![warn(clippy::all)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(fuzzing), warn(missing_docs))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! * Serde support with the `serde` feature.
 
 #![forbid(unsafe_code)]
-#![warn(clippy::all)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(fuzzing), warn(missing_docs))]
 


### PR DESCRIPTION
This PR fixes some clippy warnings and removes every last bit of the `optional` crate

- tests ran through successfully
- here are the benchmarks after the change compared to master. It's so clear what the benchmarks indicate to me. I would say the performance is round about the same but I'm also biased since I want the `optional` crate to vanish from the dependencies. I'll leave the ultimate decision up to you.

<details>
<summary>Benchmarks</summary>

```
   Compiling spade v2.2.0 (/home/aviac/repos/forks/spade)
    Finished bench [optimized] target(s) in 2.82s
     Running benches/benchmarks.rs (target/release/deps/benchmarks-f7c9b1b70afe2951)
Gnuplot not found, using plotters backend
locate benchmark (uniform)/locate (hierarchy<02>), f64
                        time:   [1.0776 µs 1.0781 µs 1.0786 µs]
                        change: [-0.8915% +0.1151% +0.8861%] (p = 0.81 > 0.05)
                        No change in performance detected.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) low mild
  1 (2.00%) high mild
  1 (2.00%) high severe
locate benchmark (uniform)/locate (hierarchy<03>), f64
                        time:   [791.11 ns 792.78 ns 795.33 ns]
                        change: [+0.8364% +1.4165% +1.8938%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 50 measurements (14.00%)
  2 (4.00%) high mild
  5 (10.00%) high severe
locate benchmark (uniform)/locate (hierarchy<04>), f64
                        time:   [708.76 ns 709.11 ns 709.51 ns]
                        change: [+0.1248% +0.5365% +0.9155%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  2 (4.00%) high mild
  3 (6.00%) high severe
locate benchmark (uniform)/locate (hierarchy<05>), f64
                        time:   [663.35 ns 663.67 ns 664.10 ns]
                        change: [-2.4425% -2.3817% -2.3201%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 50 measurements (12.00%)
  2 (4.00%) high mild
  4 (8.00%) high severe
locate benchmark (uniform)/locate (hierarchy<08>), f64
                        time:   [610.67 ns 610.87 ns 611.10 ns]
                        change: [+0.0114% +0.3148% +0.6228%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 50 measurements (16.00%)
  2 (4.00%) low mild
  2 (4.00%) high mild
  4 (8.00%) high severe
locate benchmark (uniform)/locate (hierarchy<10>), f64
                        time:   [590.51 ns 591.46 ns 593.34 ns]
                        change: [-0.0429% +0.3038% +0.8236%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 5 outliers among 50 measurements (10.00%)
  1 (2.00%) high mild
  4 (8.00%) high severe
locate benchmark (uniform)/locate (hierarchy<14>), f64
                        time:   [600.20 ns 600.45 ns 600.72 ns]
                        change: [-1.4693% +1.0132% +2.5744%] (p = 0.45 > 0.05)
                        No change in performance detected.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) low mild
  1 (2.00%) high severe
locate benchmark (uniform)/locate (hierarchy<16>), f64
                        time:   [606.88 ns 607.07 ns 607.28 ns]
                        change: [+3.7095% +3.8302% +3.9300%] (p = 0.00 < 0.05)
                        Performance has regressed.
locate benchmark (uniform)/locate (hierarchy<18>), f64
                        time:   [564.86 ns 565.04 ns 565.23 ns]
                        change: [-5.7784% -5.4022% -4.9870%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 50 measurements (10.00%)
  1 (2.00%) low mild
  1 (2.00%) high mild
  3 (6.00%) high severe
locate benchmark (uniform)/locate (hierarchy<20>), f64
                        time:   [581.77 ns 581.90 ns 582.03 ns]
                        change: [-0.0216% +0.2327% +0.4526%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) low mild
  1 (2.00%) high mild
  2 (4.00%) high severe
locate benchmark (uniform)/locate (hierarchy<32>), f64
                        time:   [590.47 ns 593.23 ns 596.06 ns]
                        change: [-0.5171% +0.1379% +0.7671%] (p = 0.68 > 0.05)
                        No change in performance detected.
Found 8 outliers among 50 measurements (16.00%)
  6 (12.00%) low severe
  1 (2.00%) low mild
  1 (2.00%) high severe
locate benchmark (uniform)/locate (hierarchy<40>), f64
                        time:   [591.95 ns 592.32 ns 592.70 ns]
                        change: [-1.6252% -1.4870% -1.3275%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  2 (4.00%) high mild
  2 (4.00%) high severe
locate benchmark (uniform)/locate (hierarchy<50>), f64
                        time:   [605.57 ns 606.11 ns 606.73 ns]
                        change: [-1.8608% -1.2462% -0.6681%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  2 (4.00%) high mild
  3 (6.00%) high severe
locate benchmark (uniform)/locate (hierarchy<64>), f64
                        time:   [635.14 ns 635.73 ns 636.47 ns]
                        change: [-0.2880% -0.1351% +0.0098%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 8 outliers among 50 measurements (16.00%)
  2 (4.00%) low mild
  2 (4.00%) high mild
  4 (8.00%) high severe
locate benchmark (uniform)/locate (hierarchy<70>), f64
                        time:   [664.54 ns 664.88 ns 665.24 ns]
                        change: [+3.1813% +3.3283% +3.4434%] (p = 0.00 < 0.05)
                        Performance has regressed.
locate benchmark (uniform)/locate (hierarchy<80>), f64
                        time:   [670.57 ns 671.06 ns 671.66 ns]
                        change: [+0.9546% +1.1440% +1.3604%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  5 (10.00%) high severe
locate benchmark (uniform)/locate (hierarchy<90>), f64
                        time:   [674.94 ns 675.36 ns 676.01 ns]
                        change: [-0.1205% -0.0126% +0.1144%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe

bulk load benchmark (small)/bulk loading on last used vertex heuristic, locally clustered/1000
                        time:   [140.97 µs 140.99 µs 141.02 µs]
                        thrpt:  [7.0911 Melem/s 7.0928 Melem/s 7.0937 Melem/s]
                 change:
                        time:   [+0.2605% +0.3249% +0.4056%] (p = 0.00 < 0.05)
                        thrpt:  [-0.4039% -0.3239% -0.2598%]
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, locally clustered/2000
                        time:   [287.01 µs 287.12 µs 287.23 µs]
                        thrpt:  [6.9631 Melem/s 6.9658 Melem/s 6.9684 Melem/s]
                 change:
                        time:   [-0.2557% -0.1042% +0.0546%] (p = 0.19 > 0.05)
                        thrpt:  [-0.0546% +0.1043% +0.2564%]
                        No change in performance detected.
Found 4 outliers among 50 measurements (8.00%)
  4 (8.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, locally clustered/3000
                        time:   [576.95 µs 578.04 µs 579.32 µs]
                        thrpt:  [5.1785 Melem/s 5.1899 Melem/s 5.1998 Melem/s]
                 change:
                        time:   [-0.4743% -0.2884% -0.1210%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1211% +0.2892% +0.4765%]
                        Change within noise threshold.
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) low mild
bulk load benchmark (small)/bulk loading on last used vertex heuristic, locally clustered/6000
                        time:   [1.3679 ms 1.3683 ms 1.3687 ms]
                        thrpt:  [4.3836 Melem/s 4.3850 Melem/s 4.3863 Melem/s]
                 change:
                        time:   [-0.4117% -0.3323% -0.2175%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2179% +0.3334% +0.4134%]
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  5 (10.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, locally clustered/10000
                        time:   [2.2982 ms 2.2996 ms 2.3015 ms]
                        thrpt:  [4.3450 Melem/s 4.3485 Melem/s 4.3512 Melem/s]
                 change:
                        time:   [+1.4075% +1.5046% +1.5947%] (p = 0.00 < 0.05)
                        thrpt:  [-1.5697% -1.4823% -1.3879%]
                        Performance has regressed.
Found 4 outliers among 50 measurements (8.00%)
  2 (4.00%) low mild
  2 (4.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, locally clustered/15000
                        time:   [3.5055 ms 3.5065 ms 3.5077 ms]
                        thrpt:  [4.2764 Melem/s 4.2777 Melem/s 4.2791 Melem/s]
                 change:
                        time:   [+0.8815% +0.9371% +0.9993%] (p = 0.00 < 0.05)
                        thrpt:  [-0.9894% -0.9284% -0.8738%]
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, uniformly distributed/1000
                        time:   [134.55 µs 134.59 µs 134.63 µs]
                        thrpt:  [7.4278 Melem/s 7.4301 Melem/s 7.4324 Melem/s]
                 change:
                        time:   [+0.1873% +0.2597% +0.3441%] (p = 0.00 < 0.05)
                        thrpt:  [-0.3429% -0.2590% -0.1869%]
                        Change within noise threshold.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) high mild
  3 (6.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, uniformly distributed/2000
                        time:   [280.66 µs 281.67 µs 282.91 µs]
                        thrpt:  [7.0694 Melem/s 7.1005 Melem/s 7.1260 Melem/s]
                 change:
                        time:   [+0.3664% +0.5597% +0.8336%] (p = 0.00 < 0.05)
                        thrpt:  [-0.8268% -0.5566% -0.3651%]
                        Change within noise threshold.
Found 6 outliers among 50 measurements (12.00%)
  1 (2.00%) high mild
  5 (10.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, uniformly distributed/3000
                        time:   [543.73 µs 544.22 µs 544.72 µs]
                        thrpt:  [5.5074 Melem/s 5.5125 Melem/s 5.5174 Melem/s]
                 change:
                        time:   [+1.0986% +1.2598% +1.4319%] (p = 0.00 < 0.05)
                        thrpt:  [-1.4117% -1.2442% -1.0867%]
                        Performance has regressed.
Found 4 outliers among 50 measurements (8.00%)
  2 (4.00%) low mild
  2 (4.00%) high mild
bulk load benchmark (small)/bulk loading on last used vertex heuristic, uniformly distributed/6000
                        time:   [1.2628 ms 1.2634 ms 1.2646 ms]
                        thrpt:  [4.7447 Melem/s 4.7490 Melem/s 4.7515 Melem/s]
                 change:
                        time:   [-0.5495% -0.4546% -0.2983%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2992% +0.4567% +0.5525%]
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, uniformly distributed/10000
                        time:   [2.1906 ms 2.1910 ms 2.1915 ms]
                        thrpt:  [4.5632 Melem/s 4.5641 Melem/s 4.5649 Melem/s]
                 change:
                        time:   [+1.6857% +1.8024% +1.8957%] (p = 0.00 < 0.05)
                        thrpt:  [-1.8605% -1.7705% -1.6578%]
                        Performance has regressed.
Found 4 outliers among 50 measurements (8.00%)
  4 (8.00%) high severe
bulk load benchmark (small)/bulk loading on last used vertex heuristic, uniformly distributed/15000
                        time:   [3.3630 ms 3.3636 ms 3.3643 ms]
                        thrpt:  [4.4586 Melem/s 4.4595 Melem/s 4.4603 Melem/s]
                 change:
                        time:   [+0.6781% +0.8368% +0.9687%] (p = 0.00 < 0.05)
                        thrpt:  [-0.9594% -0.8299% -0.6736%]
                        Change within noise threshold.
Found 6 outliers among 50 measurements (12.00%)
  1 (2.00%) low mild
  2 (4.00%) high mild
  3 (6.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, uniformly distributed/1000
                        time:   [147.07 µs 147.21 µs 147.52 µs]
                        thrpt:  [6.7788 Melem/s 6.7930 Melem/s 6.7994 Melem/s]
                 change:
                        time:   [+0.6544% +0.7312% +0.8456%] (p = 0.00 < 0.05)
                        thrpt:  [-0.8385% -0.7259% -0.6501%]
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  3 (6.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, uniformly distributed/2000
                        time:   [304.63 µs 304.79 µs 305.05 µs]
                        thrpt:  [6.5563 Melem/s 6.5620 Melem/s 6.5653 Melem/s]
                 change:
                        time:   [+0.6993% +0.7611% +0.8346%] (p = 0.00 < 0.05)
                        thrpt:  [-0.8277% -0.7553% -0.6944%]
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  2 (4.00%) high mild
  3 (6.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, uniformly distributed/3000
                        time:   [615.11 µs 615.55 µs 615.90 µs]
                        thrpt:  [4.8709 Melem/s 4.8737 Melem/s 4.8771 Melem/s]
                 change:
                        time:   [+0.6762% +0.7818% +0.8891%] (p = 0.00 < 0.05)
                        thrpt:  [-0.8812% -0.7757% -0.6716%]
                        Change within noise threshold.
bulk load benchmark (small)/bulk loading on hierarchy lookup, uniformly distributed/6000
                        time:   [1.4419 ms 1.4424 ms 1.4429 ms]
                        thrpt:  [4.1583 Melem/s 4.1598 Melem/s 4.1613 Melem/s]
                 change:
                        time:   [+0.5666% +0.6197% +0.6655%] (p = 0.00 < 0.05)
                        thrpt:  [-0.6611% -0.6158% -0.5634%]
                        Change within noise threshold.
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, uniformly distributed/10000
                        time:   [2.5228 ms 2.5234 ms 2.5241 ms]
                        thrpt:  [3.9619 Melem/s 3.9629 Melem/s 3.9638 Melem/s]
                 change:
                        time:   [+0.8568% +0.9344% +1.0103%] (p = 0.00 < 0.05)
                        thrpt:  [-1.0002% -0.9257% -0.8495%]
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  3 (6.00%) high severe
Benchmarking bulk load benchmark (small)/bulk loading on hierarchy lookup, uniformly distributed/15000: Warming up for 1.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 5.0s, enable flat sampling, or reduce sample count to 30.
bulk load benchmark (small)/bulk loading on hierarchy lookup, uniformly distributed/15000
                        time:   [3.9075 ms 3.9131 ms 3.9239 ms]
                        thrpt:  [3.8227 Melem/s 3.8333 Melem/s 3.8388 Melem/s]
                 change:
                        time:   [+1.1813% +1.5475% +2.0039%] (p = 0.00 < 0.05)
                        thrpt:  [-1.9646% -1.5239% -1.1675%]
                        Performance has regressed.
Found 7 outliers among 50 measurements (14.00%)
  2 (4.00%) high mild
  5 (10.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, locally clustered/1000
                        time:   [149.05 µs 149.10 µs 149.15 µs]
                        thrpt:  [6.7046 Melem/s 6.7068 Melem/s 6.7091 Melem/s]
                 change:
                        time:   [-0.4690% -0.3785% -0.2514%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2520% +0.3799% +0.4712%]
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, locally clustered/2000
                        time:   [309.88 µs 310.24 µs 310.80 µs]
                        thrpt:  [6.4350 Melem/s 6.4466 Melem/s 6.4540 Melem/s]
                 change:
                        time:   [-0.4185% -0.1821% +0.0763%] (p = 0.16 > 0.05)
                        thrpt:  [-0.0762% +0.1825% +0.4202%]
                        No change in performance detected.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, locally clustered/3000
                        time:   [640.36 µs 640.86 µs 641.39 µs]
                        thrpt:  [4.6773 Melem/s 4.6812 Melem/s 4.6849 Melem/s]
                 change:
                        time:   [+0.3142% +0.4697% +0.6091%] (p = 0.00 < 0.05)
                        thrpt:  [-0.6054% -0.4676% -0.3132%]
                        Change within noise threshold.
bulk load benchmark (small)/bulk loading on hierarchy lookup, locally clustered/6000
                        time:   [1.5451 ms 1.5457 ms 1.5463 ms]
                        thrpt:  [3.8802 Melem/s 3.8818 Melem/s 3.8831 Melem/s]
                 change:
                        time:   [+0.7766% +0.9968% +1.2190%] (p = 0.00 < 0.05)
                        thrpt:  [-1.2043% -0.9869% -0.7706%]
                        Change within noise threshold.
Found 11 outliers among 50 measurements (22.00%)
  11 (22.00%) high severe
bulk load benchmark (small)/bulk loading on hierarchy lookup, locally clustered/10000
                        time:   [2.6331 ms 2.6335 ms 2.6338 ms]
                        thrpt:  [3.7968 Melem/s 3.7973 Melem/s 3.7978 Melem/s]
                 change:
                        time:   [+3.1900% +3.2295% +3.2687%] (p = 0.00 < 0.05)
                        thrpt:  [-3.1652% -3.1284% -3.0914%]
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high severe
Benchmarking bulk load benchmark (small)/bulk loading on hierarchy lookup, locally clustered/15000: Warming up for 1.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 5.1s, enable flat sampling, or reduce sample count to 30.
bulk load benchmark (small)/bulk loading on hierarchy lookup, locally clustered/15000
                        time:   [3.9714 ms 3.9723 ms 3.9736 ms]
                        thrpt:  [3.7749 Melem/s 3.7761 Melem/s 3.7770 Melem/s]
                 change:
                        time:   [+1.2799% +1.3360% +1.3925%] (p = 0.00 < 0.05)
                        thrpt:  [-1.3734% -1.3184% -1.2637%]
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild

bulk load benchmark (big)/bulk loading on last used vertex heuristic, uniformly distributed/100000
                        time:   [23.775 ms 23.786 ms 23.800 ms]
                        thrpt:  [4.2017 Melem/s 4.2041 Melem/s 4.2060 Melem/s]
                 change:
                        time:   [+1.0830% +1.1389% +1.1971%] (p = 0.00 < 0.05)
                        thrpt:  [-1.1829% -1.1261% -1.0713%]
                        Performance has regressed.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe
bulk load benchmark (big)/bulk loading on last used vertex heuristic, uniformly distributed/200000
                        time:   [48.734 ms 48.750 ms 48.767 ms]
                        thrpt:  [4.1011 Melem/s 4.1026 Melem/s 4.1040 Melem/s]
                 change:
                        time:   [-0.1612% -0.1201% -0.0796%] (p = 0.00 < 0.05)
                        thrpt:  [+0.0797% +0.1203% +0.1614%]
                        Change within noise threshold.
Benchmarking bulk load benchmark (big)/bulk loading on last used vertex heuristic, uniformly distributed/400000: Warming up for 1.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 5.6s, or reduce sample count to 40.
bulk load benchmark (big)/bulk loading on last used vertex heuristic, uniformly distributed/400000
                        time:   [112.63 ms 112.73 ms 112.84 ms]
                        thrpt:  [3.5449 Melem/s 3.5483 Melem/s 3.5516 Melem/s]
                 change:
                        time:   [+1.7805% +1.9116% +2.0385%] (p = 0.00 < 0.05)
                        thrpt:  [-1.9978% -1.8758% -1.7494%]
                        Performance has regressed.
Benchmarking bulk load benchmark (big)/bulk loading on last used vertex heuristic, uniformly distributed/800000: Warming up for 1.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 12.2s, or reduce sample count to 20.
bulk load benchmark (big)/bulk loading on last used vertex heuristic, uniformly distributed/800000
                        time:   [244.63 ms 245.04 ms 245.45 ms]
                        thrpt:  [3.2593 Melem/s 3.2647 Melem/s 3.2702 Melem/s]
                 change:
                        time:   [+5.0667% +5.3584% +5.6280%] (p = 0.00 < 0.05)
                        thrpt:  [-5.3281% -5.0859% -4.8223%]
                        Performance has regressed.

bulk vs incremental loading/bulk loading on hierarchy lookup, uniformly distributed/1000
                        time:   [149.80 µs 149.82 µs 149.85 µs]
                        thrpt:  [6.6735 Melem/s 6.6746 Melem/s 6.6756 Melem/s]
                 change:
                        time:   [+2.6306% +2.7348% +2.8325%] (p = 0.00 < 0.05)
                        thrpt:  [-2.7545% -2.6620% -2.5632%]
                        Performance has regressed.
Found 6 outliers among 50 measurements (12.00%)
  6 (12.00%) high mild
bulk vs incremental loading/bulk loading on hierarchy lookup, uniformly distributed/2000
                        time:   [305.24 µs 305.68 µs 306.38 µs]
                        thrpt:  [6.5277 Melem/s 6.5429 Melem/s 6.5522 Melem/s]
                 change:
                        time:   [+0.7643% +0.9598% +1.1429%] (p = 0.00 < 0.05)
                        thrpt:  [-1.1300% -0.9507% -0.7585%]
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high severe
bulk vs incremental loading/bulk loading on hierarchy lookup, uniformly distributed/3000
                        time:   [626.51 µs 626.89 µs 627.26 µs]
                        thrpt:  [4.7827 Melem/s 4.7855 Melem/s 4.7885 Melem/s]
                 change:
                        time:   [-0.7665% +0.0799% +0.9129%] (p = 0.85 > 0.05)
                        thrpt:  [-0.9046% -0.0799% +0.7725%]
                        No change in performance detected.
bulk vs incremental loading/bulk loading on hierarchy lookup, uniformly distributed/6000
                        time:   [1.4657 ms 1.4660 ms 1.4665 ms]
                        thrpt:  [4.0915 Melem/s 4.0927 Melem/s 4.0937 Melem/s]
                 change:
                        time:   [-0.6563% +0.9208% +1.9710%] (p = 0.20 > 0.05)
                        thrpt:  [-1.9329% -0.9124% +0.6607%]
                        No change in performance detected.
Found 4 outliers among 50 measurements (8.00%)
  4 (8.00%) high mild
bulk vs incremental loading/bulk loading on hierarchy lookup, uniformly distributed/10000
                        time:   [2.5419 ms 2.5426 ms 2.5433 ms]
                        thrpt:  [3.9319 Melem/s 3.9330 Melem/s 3.9340 Melem/s]
                 change:
                        time:   [+0.4481% +0.5999% +0.7180%] (p = 0.00 < 0.05)
                        thrpt:  [-0.7129% -0.5963% -0.4461%]
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe
Benchmarking bulk vs incremental loading/bulk loading on hierarchy lookup, uniformly distributed/15000: Warming up for 1.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 5.1s, enable flat sampling, or reduce sample count to 30.
bulk vs incremental loading/bulk loading on hierarchy lookup, uniformly distributed/15000
                        time:   [3.9256 ms 3.9319 ms 3.9406 ms]
                        thrpt:  [3.8065 Melem/s 3.8150 Melem/s 3.8211 Melem/s]
                 change:
                        time:   [+1.2419% +1.4583% +1.6823%] (p = 0.00 < 0.05)
                        thrpt:  [-1.6545% -1.4373% -1.2267%]
                        Performance has regressed.
bulk vs incremental loading/incremental loading on hierarchy lookup, uniformly distributed/1000
                        time:   [219.13 µs 219.45 µs 219.88 µs]
                        thrpt:  [4.5480 Melem/s 4.5568 Melem/s 4.5635 Melem/s]
                 change:
                        time:   [-3.5594% -3.3019% -3.1040%] (p = 0.00 < 0.05)
                        thrpt:  [+3.2034% +3.4147% +3.6908%]
                        Performance has improved.
bulk vs incremental loading/incremental loading on hierarchy lookup, uniformly distributed/2000
                        time:   [716.33 µs 716.57 µs 716.81 µs]
                        thrpt:  [2.7901 Melem/s 2.7911 Melem/s 2.7920 Melem/s]
                 change:
                        time:   [+6.4502% +6.6478% +6.8383%] (p = 0.00 < 0.05)
                        thrpt:  [-6.4006% -6.2334% -6.0594%]
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) low mild
bulk vs incremental loading/incremental loading on hierarchy lookup, uniformly distributed/3000
                        time:   [1.2828 ms 1.2831 ms 1.2834 ms]
                        thrpt:  [2.3375 Melem/s 2.3380 Melem/s 2.3386 Melem/s]
                 change:
                        time:   [+2.4230% +2.4612% +2.5005%] (p = 0.00 < 0.05)
                        thrpt:  [-2.4395% -2.4021% -2.3657%]
                        Performance has regressed.
Found 6 outliers among 50 measurements (12.00%)
  1 (2.00%) low severe
  2 (4.00%) low mild
  3 (6.00%) high mild
bulk vs incremental loading/incremental loading on hierarchy lookup, uniformly distributed/6000
                        time:   [2.8289 ms 2.8291 ms 2.8293 ms]
                        thrpt:  [2.1206 Melem/s 2.1208 Melem/s 2.1210 Melem/s]
                 change:
                        time:   [+0.6152% +0.7204% +0.8197%] (p = 0.00 < 0.05)
                        thrpt:  [-0.8130% -0.7153% -0.6114%]
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) low mild
  2 (4.00%) high severe
Benchmarking bulk vs incremental loading/incremental loading on hierarchy lookup, uniformly distributed/10000: Warming up for 1.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 6.5s, enable flat sampling, or reduce sample count to 30.
bulk vs incremental loading/incremental loading on hierarchy lookup, uniformly distributed/10000
                        time:   [5.0637 ms 5.0646 ms 5.0654 ms]
                        thrpt:  [1.9742 Melem/s 1.9745 Melem/s 1.9748 Melem/s]
                 change:
                        time:   [+0.8493% +0.9221% +0.9932%] (p = 0.00 < 0.05)
                        thrpt:  [-0.9835% -0.9137% -0.8422%]
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild
bulk vs incremental loading/incremental loading on hierarchy lookup, uniformly distributed/15000
                        time:   [8.0719 ms 8.0782 ms 8.0854 ms]
                        thrpt:  [1.8552 Melem/s 1.8568 Melem/s 1.8583 Melem/s]
                 change:
                        time:   [+0.0807% +0.1634% +0.2605%] (p = 0.00 < 0.05)
                        thrpt:  [-0.2598% -0.1632% -0.0807%]
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  3 (6.00%) high mild
  2 (4.00%) high severe
```

</details>

Feel free to just close the PR if you don't want the change.


---


Related to https://github.com/Stoeoef/spade/issues/89