### PR TITLE
No_std with alloc. Compiles, tests pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,22 @@ autobenches = false
 [lib]
 bench = false
 
+[features]
+default = [ "std" ]
+std = []
+
 [dependencies]
 smallvec = "1"
 robust = "1.1.0"
 num-traits = "0.2"
+hashbrown  = "0.14.2"
 
 [dependencies.serde]
 package = "serde"
 optional = true
 version = "1"
-features = ["derive"]
+default-features = false
+features = [ "derive", "alloc" ]
 
 [workspace]
 members = ["delaunay_compare"]

--- a/benches/benchmark_utilities.rs
+++ b/benches/benchmark_utilities.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display, Formatter};
+use core::fmt::{self, Display, Formatter};
 
 use criterion::{measurement::WallTime, BenchmarkGroup, BenchmarkId, Throughput};
 use rand::{distributions::uniform::SampleUniform, Rng, SeedableRng};
@@ -29,7 +29,7 @@ where
 {
     let range = rand::distributions::Uniform::new_inclusive(-range, range);
     let mut rng = rand::rngs::StdRng::from_seed(seed);
-    std::iter::from_fn(move || Some(Point2::new(rng.sample(range), rng.sample(range))))
+    core::iter::from_fn(move || Some(Point2::new(rng.sample(range), rng.sample(range))))
 }
 
 pub fn uniform_f64() -> impl Iterator<Item = Point2<f64>> {
@@ -54,7 +54,7 @@ where
 
         Some(Point2::new(last_x, last_y))
     };
-    std::iter::from_fn(step_fn)
+    core::iter::from_fn(step_fn)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/delaunay_compare/benches/bench_utilities.rs
+++ b/delaunay_compare/benches/bench_utilities.rs
@@ -14,7 +14,7 @@ where
 {
     let range = rand::distributions::Uniform::new_inclusive(-range, range);
     let mut rng = StdRng::from_seed(seed);
-    std::iter::from_fn(move || Some([rng.sample(range), rng.sample(range)]))
+    core::iter::from_fn(move || Some([rng.sample(range), rng.sample(range)]))
 }
 
 pub fn uniform_f64() -> impl Iterator<Item = [f64; 2]> {
@@ -41,5 +41,5 @@ where
 
         Some([last_x, last_y])
     };
-    std::iter::from_fn(step_fn)
+    core::iter::from_fn(step_fn)
 }

--- a/delaunay_compare/src/spade_crate.rs
+++ b/delaunay_compare/src/spade_crate.rs
@@ -5,7 +5,7 @@ type SpadePoint = spade::Point2<f64>;
 #[derive(Default)]
 pub struct SpadeCrateWithHintGenerator<HintGeneratorType> {
     vertices: Vec<SpadePoint>,
-    _hint_generator_type: std::marker::PhantomData<HintGeneratorType>,
+    _hint_generator_type: core::marker::PhantomData<HintGeneratorType>,
 }
 
 pub type SpadeCrate = SpadeCrateWithHintGenerator<spade::LastUsedVertexHintGenerator>;

--- a/examples/svg_renderer/main.rs
+++ b/examples/svg_renderer/main.rs
@@ -2,7 +2,7 @@ pub mod quicksketch;
 mod scenario;
 mod scenario_list;
 
-type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+type Result = core::result::Result<(), Box<dyn std::error::Error>>;
 
 /// Used for rendering SVGs for documentation. These are inlined (via #[doc = include_str!(...)])
 /// into the doc comment of a few items. That makes sure they will be visible even for offline users.

--- a/examples/svg_renderer/quicksketch/color.rs
+++ b/examples/svg_renderer/quicksketch/color.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use core::fmt::Display;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Copy)]
 pub struct SketchColor {
@@ -8,7 +8,7 @@ pub struct SketchColor {
 }
 
 impl Display for SketchColor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "rgb({} {} {})", self.red, self.green, self.blue)
     }
 }

--- a/examples/svg_renderer/quicksketch/mod.rs
+++ b/examples/svg_renderer/quicksketch/mod.rs
@@ -178,7 +178,7 @@ impl Style {
             stroke_dash_array,
         ])
         .flatten()
-        .chain(std::iter::once(fill))
+        .chain(core::iter::once(fill))
         .collect::<Vec<_>>()
         .join("; ")
     }

--- a/fuzz/fuzz_targets/bulk_load_fuzz.rs
+++ b/fuzz/fuzz_targets/bulk_load_fuzz.rs
@@ -27,8 +27,8 @@ pub struct FuzzPoint {
     y: f64,
 }
 
-impl std::fmt::Debug for FuzzPoint {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for FuzzPoint {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("Point2::new({:?}, {:?})", self.x, self.y))
     }
 }

--- a/fuzz/fuzz_targets/bulk_load_int_fuzz.rs
+++ b/fuzz/fuzz_targets/bulk_load_int_fuzz.rs
@@ -26,8 +26,8 @@ pub struct IntFuzzPoint {
     y: i32,
 }
 
-impl std::fmt::Debug for IntFuzzPoint {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for IntFuzzPoint {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("Point2::new({:?}.0, {:?}.0)", self.x, self.y))
     }
 }

--- a/src/cdt.rs
+++ b/src/cdt.rs
@@ -7,6 +7,8 @@ use crate::{
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use alloc::{vec, vec::Vec};
+
 /// Undirected edge type of a [ConstrainedDelaunayTriangulation] (CDT).
 ///
 /// CDTs need to store if an undirected edge is a constrained edge. To do so, CDTs don't use
@@ -362,7 +364,7 @@ where
                 VertexOutDirection::EdgeIntersection(edge) => edge,
             };
 
-            let mut border_loop = std::collections::VecDeque::new();
+            let mut border_loop = alloc::collections::VecDeque::new();
 
             border_loop.push_back(first_edge.rev().next().fix());
             border_loop.push_front(first_edge.rev().prev().fix());
@@ -552,6 +554,8 @@ mod test {
     type Cdt = ConstrainedDelaunayTriangulation<Point2<f64>>;
     type Delaunay = DelaunayTriangulation<Point2<f64>>;
 
+    use alloc::{vec, vec::Vec};
+
     #[test]
     fn test_add_single_simple_constraint() -> Result<(), InsertionError> {
         let mut cdt = Cdt::new();
@@ -657,7 +661,7 @@ mod test {
     fn test_add_border_constraint() -> Result<(), InsertionError> {
         let points = random_points_with_seed(1000, SEED);
         let mut cdt = Cdt::new();
-        let mut max_y = -::std::f64::MAX;
+        let mut max_y = -::core::f64::MAX;
         for point in points {
             max_y = max_y.max(point.y);
             cdt.insert(point)?;
@@ -695,7 +699,8 @@ mod test {
         for p in delaunay_points {
             d.insert(p)?;
         }
-        let mut used_vertices = ::std::collections::HashSet::new();
+        let mut used_vertices = ::hashbrown::HashSet::new();
+
         let mut inserted_constraints = Vec::new();
         for v in d.vertices() {
             // Insert only edges that do not touch at the end points if

--- a/src/delaunay_core/bulk_load.rs
+++ b/src/delaunay_core/bulk_load.rs
@@ -1,8 +1,10 @@
-use std::cmp::{Ordering, Reverse};
+use core::cmp::{Ordering, Reverse};
 
 use crate::{HasPosition, InsertionError, Point2, Triangulation, TriangulationExt};
 
 use super::{dcel_operations, FixedDirectedEdgeHandle, FixedUndirectedEdgeHandle};
+
+use alloc::vec::Vec;
 
 /// An `f64` wrapper implementing `Ord` and `Eq`.
 ///
@@ -469,7 +471,7 @@ impl Hull {
 
         const INVALID: usize = usize::MAX;
         self.buckets
-            .extend(std::iter::repeat(INVALID).take(target_size));
+            .extend(core::iter::repeat(INVALID).take(target_size));
 
         let (first_index, current_node) = self
             .data
@@ -752,6 +754,8 @@ mod test {
     use crate::{DelaunayTriangulation, InsertionError, Point2, Triangulation, TriangulationExt};
 
     use super::Hull;
+
+    use alloc::vec::Vec;
 
     #[test]
     fn test_bulk_load_with_small_number_of_vertices() -> Result<(), InsertionError> {

--- a/src/delaunay_core/bulk_load_fuzz_tests.rs
+++ b/src/delaunay_core/bulk_load_fuzz_tests.rs
@@ -1,5 +1,7 @@
 use crate::{DelaunayTriangulation, Point2, Triangulation, TriangulationExt};
 
+use alloc::{vec, vec::Vec};
+
 fn fuzz_test(vertices: Vec<Point2<f64>>) {
     let mut clone = vertices.clone();
     clone.sort_by(|l, r| l.partial_cmp(r).unwrap());

--- a/src/delaunay_core/dcel.rs
+++ b/src/delaunay_core/dcel.rs
@@ -5,6 +5,8 @@ use super::handles::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use alloc::vec::Vec;
+
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Hash)]
 pub struct EdgeData<DE, UE> {
     directed_data: [DE; 2],

--- a/src/delaunay_core/dcel_operations.rs
+++ b/src/delaunay_core/dcel_operations.rs
@@ -5,6 +5,8 @@ use super::handles::*;
 
 use smallvec::SmallVec;
 
+use alloc::{vec, vec::Vec};
+
 pub const OUTER_FACE_HANDLE: FixedFaceHandle<PossiblyOuterTag> = new_fixed_face_handle(0);
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1307,6 +1309,8 @@ mod test {
     use crate::handles::{InnerTag, VertexHandle};
 
     use super::{Dcel, FixedDirectedEdgeHandle, FixedFaceHandle, FixedVertexHandle};
+
+    use alloc::{vec, vec::Vec};
 
     fn default_triangle() -> Dcel<usize, (), ()> {
         use super::{EdgeEntry, FaceEntry, HalfEdgeEntry, VertexEntry};

--- a/src/delaunay_core/handles/handle_defs.rs
+++ b/src/delaunay_core/handles/handle_defs.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use super::super::Dcel;
 use super::public_handles::{InnerOuterMarker, PossiblyOuterTag};
@@ -27,8 +27,8 @@ pub struct FixedHandleImpl<Type, InnerOuter: InnerOuterMarker> {
     inner_outer: InnerOuter,
 }
 
-impl<Type, InnerOuter: InnerOuterMarker> std::fmt::Debug for FixedHandleImpl<Type, InnerOuter> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<Type, InnerOuter: InnerOuterMarker> core::fmt::Debug for FixedHandleImpl<Type, InnerOuter> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("FixedHandle")
             .field("index", &self.index)
             .finish()

--- a/src/delaunay_core/handles/handle_impls.rs
+++ b/src/delaunay_core/handles/handle_impls.rs
@@ -6,20 +6,20 @@ use super::iterators::NextBackFn;
 use super::public_handles::*;
 
 use crate::{HasPosition, LineSideInfo, Point2};
+use core::cmp::Ordering;
+use core::fmt::Debug;
+use core::hash::{Hash, Hasher};
 use num_traits::{Float, One};
-use std::cmp::Ordering;
-use std::fmt::Debug;
-use std::hash::{Hash, Hasher};
 
 // Debug implementations
-impl<'a, V, DE, UE, F> std::fmt::Debug for VertexHandle<'a, V, DE, UE, F> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl<'a, V, DE, UE, F> core::fmt::Debug for VertexHandle<'a, V, DE, UE, F> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "VertexHandle({:?})", self.handle.index())
     }
 }
 
 impl<'a, V, DE, UE, F> Debug for DirectedEdgeHandle<'a, V, DE, UE, F> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(
             f,
             "DirectedEdgeHandle - id: {:?} ({:?} -> {:?})",
@@ -30,8 +30,8 @@ impl<'a, V, DE, UE, F> Debug for DirectedEdgeHandle<'a, V, DE, UE, F> {
     }
 }
 
-impl<'a, V, DE, UE, F> std::fmt::Debug for UndirectedEdgeHandle<'a, V, DE, UE, F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> ::std::fmt::Result {
+impl<'a, V, DE, UE, F> core::fmt::Debug for UndirectedEdgeHandle<'a, V, DE, UE, F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> ::core::fmt::Result {
         let [v0, v1] = self.vertices();
         write!(
             f,
@@ -43,8 +43,8 @@ impl<'a, V, DE, UE, F> std::fmt::Debug for UndirectedEdgeHandle<'a, V, DE, UE, F
     }
 }
 
-impl<'a, V, DE, UE, F> std::fmt::Debug for FaceHandle<'a, PossiblyOuterTag, V, DE, UE, F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> ::std::fmt::Result {
+impl<'a, V, DE, UE, F> core::fmt::Debug for FaceHandle<'a, PossiblyOuterTag, V, DE, UE, F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> ::core::fmt::Result {
         if let Some(inner) = self.as_inner() {
             inner.fmt(f)
         } else {
@@ -53,8 +53,8 @@ impl<'a, V, DE, UE, F> std::fmt::Debug for FaceHandle<'a, PossiblyOuterTag, V, D
     }
 }
 
-impl<'a, V, DE, UE, F> std::fmt::Debug for FaceHandle<'a, InnerTag, V, DE, UE, F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> ::std::fmt::Result {
+impl<'a, V, DE, UE, F> core::fmt::Debug for FaceHandle<'a, InnerTag, V, DE, UE, F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> ::core::fmt::Result {
         let [v0, v1, v2] = self.vertices();
         write!(
             f,

--- a/src/delaunay_core/handles/iterators/circular_iterator.rs
+++ b/src/delaunay_core/handles/iterators/circular_iterator.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::super::DirectedEdgeHandle;
 

--- a/src/delaunay_core/handles/iterators/fixed_iterators.rs
+++ b/src/delaunay_core/handles/iterators/fixed_iterators.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::super::handle_defs::{DelaunayElementType, DynamicHandleImpl, FixedHandleImpl};
 use super::super::InnerOuterMarker;
@@ -6,7 +6,7 @@ use super::super::InnerOuterMarker;
 use crate::delaunay_core::Dcel;
 
 pub struct FixedHandleIterator<Type, InnerOuter> {
-    range: std::ops::Range<usize>,
+    range: core::ops::Range<usize>,
     ty: PhantomData<Type>,
     inner_outer: PhantomData<InnerOuter>,
 }
@@ -59,7 +59,7 @@ impl<Type: Default, InnerOuter: InnerOuterMarker> DoubleEndedIterator
 pub struct DynamicHandleIterator<'a, V, DE, UE, F, Type, InnerOuter> {
     fixed_iterator: FixedHandleIterator<Type, InnerOuter>,
     dcel: &'a Dcel<V, DE, UE, F>,
-    inner_outer: std::marker::PhantomData<InnerOuter>,
+    inner_outer: core::marker::PhantomData<InnerOuter>,
 }
 
 impl<'a, V, DE, UE, F, Type, InnerOuter> DynamicHandleIterator<'a, V, DE, UE, F, Type, InnerOuter>
@@ -71,7 +71,7 @@ where
         DynamicHandleIterator {
             fixed_iterator: FixedHandleIterator::new(Type::num_elements(dcel)),
             dcel,
-            inner_outer: std::marker::PhantomData,
+            inner_outer: core::marker::PhantomData,
         }
     }
 }

--- a/src/delaunay_core/handles/iterators/hull_iterator.rs
+++ b/src/delaunay_core/handles/iterators/hull_iterator.rs
@@ -58,6 +58,9 @@ impl<'a, V, DE, UE, F> DoubleEndedIterator for HullIterator<'a, V, DE, UE, F> {
 
 #[cfg(test)]
 mod test {
+
+    use alloc::vec::Vec;
+
     use crate::test_utilities::{random_points_with_seed, SEED};
     use crate::{DelaunayTriangulation, InsertionError, Point2, Triangulation};
 

--- a/src/delaunay_core/handles/public_handles.rs
+++ b/src/delaunay_core/handles/public_handles.rs
@@ -19,7 +19,7 @@ pub const OUTER_FACE: FixedFaceHandle<PossiblyOuterTag> = dcel_operations::OUTER
 ///
 /// There should be no need to implement this.
 pub trait InnerOuterMarker:
-    Clone + Copy + PartialEq + Eq + PartialOrd + Ord + std::fmt::Debug + Default + std::hash::Hash
+    Clone + Copy + PartialEq + Eq + PartialOrd + Ord + core::fmt::Debug + Default + core::hash::Hash
 {
     fn debug_string() -> &'static str;
 }

--- a/src/delaunay_core/hint_generator.rs
+++ b/src/delaunay_core/hint_generator.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{
     DelaunayTriangulation, HasPosition, Point2, SpadeNum, Triangulation, TriangulationExt,
@@ -8,6 +8,8 @@ use super::FixedVertexHandle;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use alloc::vec::Vec;
 
 /// A structure used to speed up common operations on delaunay triangulations like insertion and geometry queries by providing
 /// hints on where to start searching for elements.
@@ -287,6 +289,8 @@ mod test {
         handles::FixedVertexHandle, test_utilities, DelaunayTriangulation, InsertionError, Point2,
         Triangulation, TriangulationExt,
     };
+
+    use alloc::vec::Vec;
 
     const BRANCH_FACTOR: u32 = 3;
 

--- a/src/delaunay_core/math.rs
+++ b/src/delaunay_core/math.rs
@@ -1,5 +1,3 @@
-use std::{error::Error, fmt::Display};
-
 use crate::{HasPosition, LineSideInfo, Point2, SpadeNum};
 use num_traits::Float;
 
@@ -35,13 +33,14 @@ pub enum InsertionError {
     NAN,
 }
 
-impl Display for InsertionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <Self as std::fmt::Debug>::fmt(self, f)
+impl core::fmt::Display for InsertionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <Self as core::fmt::Debug>::fmt(self, f)
     }
 }
 
-impl Error for InsertionError {}
+#[cfg(feature = "std")]
+impl std::error::Error for InsertionError {}
 
 /// The smallest allowed coordinate value greater than zero that can be inserted into Delaunay
 /// triangulations. This value is equal to 2<sup>-142</sup>.

--- a/src/delaunay_core/triangulation_ext.rs
+++ b/src/delaunay_core/triangulation_ext.rs
@@ -9,6 +9,8 @@ use crate::HintGenerator;
 use crate::Point2;
 use crate::{HasPosition, InsertionError, PositionInTriangulation, Triangulation};
 
+use alloc::{collections::VecDeque, vec::Vec};
+
 impl<T> TriangulationExt for T where T: Triangulation + ?Sized {}
 
 pub enum PositionWhenAllVerticesOnLine {
@@ -261,7 +263,7 @@ pub trait TriangulationExt: Triangulation {
         position: Point2<<Self::Vertex as HasPosition>::Scalar>,
         forward_predicate: ForwardPredicate,
         backward_predicate: BackwardPredicate,
-    ) -> std::collections::VecDeque<FixedDirectedEdgeHandle>
+    ) -> VecDeque<FixedDirectedEdgeHandle>
     where
         ForwardPredicate: Fn(
             DirectedEdgeHandle<Self::Vertex, Self::DirectedEdge, Self::UndirectedEdge, Self::Face>,
@@ -270,7 +272,7 @@ pub trait TriangulationExt: Triangulation {
             DirectedEdgeHandle<Self::Vertex, Self::DirectedEdge, Self::UndirectedEdge, Self::Face>,
         ) -> bool,
     {
-        let mut result = std::collections::VecDeque::with_capacity(8);
+        let mut result = VecDeque::with_capacity(8);
         let mut current_edge_forward = self.directed_edge(start_edge);
 
         debug_assert!(current_edge_forward.side_query(position).is_on_left_side());
@@ -635,7 +637,7 @@ pub trait TriangulationExt: Triangulation {
                 vertex_to_remove,
             );
             // Not exactly elegant. IsolateVertexResult should maybe be split into two parts
-            let mut new_edges = std::mem::take(&mut isolation_result.new_edges);
+            let mut new_edges = core::mem::take(&mut isolation_result.new_edges);
             self.legalize_edges_after_removal(&mut new_edges, |edge| {
                 !isolation_result.is_new_edge(edge)
             });
@@ -860,6 +862,8 @@ mod test {
     use rand::distributions::{Distribution, Uniform};
     use rand::{seq::SliceRandom, Rng, SeedableRng};
 
+    use alloc::{vec, vec::Vec};
+
     #[test]
     fn test_empty() {
         let d = DelaunayTriangulation::<Point2<f32>>::default();
@@ -976,7 +980,7 @@ mod test {
     fn test_insert_outside_convex_hull() -> Result<(), InsertionError> {
         const NUM: usize = 100;
         let mut rng = rand::rngs::StdRng::from_seed(*SEED);
-        let range = Uniform::new(0., 2.0 * ::std::f64::consts::PI);
+        let range = Uniform::new(0., 2.0 * ::core::f64::consts::PI);
 
         let mut d = DelaunayTriangulation::<_>::default();
 

--- a/src/flood_fill_iterator.rs
+++ b/src/flood_fill_iterator.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashSet, VecDeque};
+use alloc::{collections::VecDeque, vec::Vec};
+use hashbrown::HashSet;
 
 use num_traits::{one, zero, Float};
 use smallvec::smallvec;
@@ -554,6 +555,9 @@ where
 
 #[cfg(test)]
 mod test {
+
+    use alloc::{vec, vec::Vec};
+
     use crate::{
         flood_fill_iterator::{CircleMetric, DistanceMetric, RectangleMetric},
         test_utilities::random_points_with_seed,

--- a/src/intersection_iterator.rs
+++ b/src/intersection_iterator.rs
@@ -24,11 +24,11 @@ where
     EdgeOverlap(DirectedEdgeHandle<'a, V, DE, UE, F>),
 }
 
-impl<'a, V, DE, UE, F> ::std::fmt::Debug for Intersection<'a, V, DE, UE, F>
+impl<'a, V, DE, UE, F> ::core::fmt::Debug for Intersection<'a, V, DE, UE, F>
 where
     V: HasPosition,
 {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         use self::Intersection::*;
         match self {
             EdgeIntersection(handle) => write!(f, "EdgeIntersection({:?})", handle),
@@ -413,6 +413,8 @@ mod test {
     use self::Intersection::*;
     use super::*;
     use crate::{InsertionError, Point2, Triangulation as _};
+
+    use alloc::{vec, vec::Vec};
 
     type Triangulation = crate::DelaunayTriangulation<Point2<f64>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,16 @@
 //! * Supports vertex removal
 //! * Serde support with the `serde` feature.
 
+#![no_std]
 #![forbid(unsafe_code)]
 #![warn(clippy::all)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(fuzzing), warn(missing_docs))]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
 
 mod cdt;
 mod delaunay_core;

--- a/src/point.rs
+++ b/src/point.rs
@@ -10,12 +10,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// This type should usually be either `f32` or `f64`.
 pub trait SpadeNum:
-    Num + PartialOrd + Into<f64> + From<f32> + Copy + Signed + std::fmt::Debug
+    Num + PartialOrd + Into<f64> + From<f32> + Copy + Signed + core::fmt::Debug
 {
 }
 
 impl<T> SpadeNum for T where
-    T: Num + PartialOrd + Into<f64> + From<f32> + Copy + Signed + std::fmt::Debug
+    T: Num + PartialOrd + Into<f64> + From<f32> + Copy + Signed + core::fmt::Debug
 {
 }
 

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -6,6 +6,8 @@ use rand::SeedableRng;
 pub const SEED: &[u8; 32] = b"wPYxAkIiHcEmSBAxQFoXFrpYToCe1B71";
 pub const SEED2: &[u8; 32] = b"14LzG37Y9EHTcmLW8vBDqWwtYsCeVVyF";
 
+use alloc::vec::Vec;
+
 pub fn random_points_in_range(range: f64, size: usize, seed: &[u8; 32]) -> Vec<Point2<f64>> {
     let mut rng = rand::rngs::StdRng::from_seed(*seed);
     let range = Uniform::new(-range, range);

--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -12,6 +12,8 @@ use crate::HintGenerator;
 use crate::{delaunay_core::Dcel, handles::*};
 use crate::{HasPosition, InsertionError, Point2, TriangulationExt};
 
+use alloc::vec::Vec;
+
 /// Describes a position in a triangulation.
 ///
 /// The position is set in relation to the triangulation's vertices, edges and faces.


### PR DESCRIPTION
Changes many std usages to core, vectors from `alloc` through feature with `hashbrown` crate for HashMap/Set.
Honestly I don't know how much of it actually compiles with pure no_std, probably very little, but I just wished for no_std with alloc, hence this PR.
I have not used this in a real app/lib yet, but I hope the changes are trivial on its own. Sadly it introduces a bit of a mess in code.
I am open to any opinions, refactors, etc. Its definitely not perfectly done. Its okay if you don't want to merge this, I'll keep the fork, but it would be really cool if it did.