### PR TITLE
Reworks locate algorithm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.10.0] - 2024-07-25
+
+### Added
+
+- Added basic `mint` support via the `mint` feature
+- Implements `Triangulation::get_vertex(FixedVertexHandle)` (See #106)
+
+### Fix
+
+- Fixes potential crash when inserting / locating vertices (See #107)
+
 ## [2.9.0] - 2024-06-14
 
 ### Added
@@ -436,7 +447,9 @@ A lot has changed for the 1.0. release, only larger changes are shown.
 
 Initial commit
 
-[2.8.0]: https://github.com/Stoeoef/spade/compare/v2.8.0...v2.9.0
+[2.10.0]: https://github.com/Stoeoef/spade/compare/v2.9.0...v2.10.0
+
+[2.9.0]: https://github.com/Stoeoef/spade/compare/v2.8.0...v2.9.0
 
 [2.8.0]: https://github.com/Stoeoef/spade/compare/v2.7.0...v2.8.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,12 @@ version = "1.0.0"
 default-features = false
 features = ["derive", "alloc"]
 
+[dependencies.mint]
+package = "mint"
+optional = true
+default-features = false
+version = "0.5.9"
+
 [workspace]
 members = ["delaunay_compare"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,6 @@ shapefile = "0.6.0"
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/src/cdt.rs
+++ b/src/cdt.rs
@@ -1706,6 +1706,37 @@ mod test {
         Ok(())
     }
 
+    #[test]
+    pub fn infinite_loop_2() -> Result<(), InsertionError> {
+        let lines = [
+            [
+                Point2::new(0.9296344883099084, 0.03071359966930065),
+                Point2::new(0.26031306872107085, 0.34491289915959455),
+            ],
+            [
+                Point2::new(0.7384289920396423, 0.4981747664368982),
+                Point2::new(0.06543525273452533, 0.34139896206401854),
+            ],
+            [
+                Point2::new(0.9535295221136963, 0.9114305148801416),
+                Point2::new(0.8306091165247367, 0.08959389670590667),
+            ],
+        ];
+
+        let mut cdt = ConstrainedDelaunayTriangulation::<Point2<f64>>::new();
+
+        for [a, b] in lines {
+            let a = cdt.insert(a)?;
+            let b = cdt.insert(b)?;
+
+            cdt.add_constraint_and_split(a, b, |v| v);
+        }
+
+        // This insertion used to fail as the position could not be located
+        cdt.insert(Point2::new(0.5138795569454557, 0.3186272217036502))?;
+        Ok(())
+    }
+
     fn get_cdt_for_try_add_constraint() -> Result<Cdt, InsertionError> {
         let vertices = vec![
             Point2::new(0.0, -10.0),

--- a/src/delaunay_core/bulk_load.rs
+++ b/src/delaunay_core/bulk_load.rs
@@ -339,7 +339,7 @@ where
     None
 }
 
-pub struct PointWithIndex<V> {
+pub(crate) struct PointWithIndex<V> {
     data: V,
     index: usize,
 }

--- a/src/delaunay_core/dcel.rs
+++ b/src/delaunay_core/dcel.rs
@@ -133,6 +133,10 @@ impl<V, DE, UE, F> Dcel<V, DE, UE, F> {
         self.faces.truncate(1); // Keep outer face
     }
 
+    pub fn get_vertex(&self, handle: FixedVertexHandle) -> Option<VertexHandle<V, DE, UE, F>> {
+        (handle.index() < self.vertices.len()).then(|| self.vertex(handle))
+    }
+
     pub fn map_vertices<M, V2>(self, f: M) -> Dcel<V2, DE, UE, F>
     where
         M: Fn(V) -> V2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,15 @@
 //! * Serde support with the `serde` feature.
 //! * `no_std` support with `default-features = false`
 //! * Natural neighbor interpolation: [NaturalNeighbor]
+//!
+//! # Cargo features
+//!
+//! These features are disabled by default and need to be enabled in your `Cargo.toml`:
+//!  - `serde`: Enable (de)serialization of (constrained) Delaunay triangulations with the
+//!    [Serde](https://docs.rs/serde/latest/serde/) crate
+//!  - `mint`: Enables rudimentary [mint](https://docs.rs/mint/latest/mint/) interoperability by
+//!    implementing the `From` and `Into` conversion traits between `spade::Point2` and
+//!    `mint::Point2`. Also implements [HasPosition] for `mint::Point2`.
 
 #![no_std]
 #![forbid(unsafe_code)]
@@ -59,6 +68,8 @@ pub use delaunay_core::TriangulationExt;
 
 pub(crate) use delaunay_core::RemovalResult;
 
+#[cfg(feature = "mint")]
+mod mint_support;
 #[cfg(test)]
 mod test_utilities;
 

--- a/src/mint_support.rs
+++ b/src/mint_support.rs
@@ -1,0 +1,27 @@
+use crate::{HasPosition, SpadeNum};
+
+impl<S> HasPosition for mint::Point2<S>
+where
+    S: SpadeNum,
+{
+    type Scalar = S;
+
+    fn position(&self) -> crate::Point2<Self::Scalar> {
+        (*self).into()
+    }
+}
+
+impl<S> From<mint::Point2<S>> for crate::Point2<S> {
+    fn from(value: mint::Point2<S>) -> Self {
+        crate::Point2::new(value.x, value.y)
+    }
+}
+
+impl<S> From<crate::Point2<S>> for mint::Point2<S> {
+    fn from(value: crate::Point2<S>) -> Self {
+        mint::Point2 {
+            x: value.x,
+            y: value.y,
+        }
+    }
+}

--- a/src/point.rs
+++ b/src/point.rs
@@ -116,7 +116,7 @@ impl<S: SpadeNum> From<(S, S)> for Point2<S> {
     }
 }
 
-/// An object with position.
+/// An object with a position.
 ///
 /// Vertices need to implement this trait to allow being inserted into triangulations.
 pub trait HasPosition {

--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -322,6 +322,19 @@ pub trait Triangulation: Default {
         self.s().fixed_vertices()
     }
 
+    /// Get a vertex by its index
+    ///
+    /// To get the handle, wrap your local index in a FixedVertexHandle:
+    /// `let handle = FixedVertexHandle::from_index(my_index);`
+    #[allow(clippy::type_complexity)]
+    fn get_vertex(
+        &self,
+        handle: FixedVertexHandle,
+    ) -> Option<VertexHandle<Self::Vertex, Self::DirectedEdge, Self::UndirectedEdge, Self::Face>>
+    {
+        self.s().get_vertex(handle)
+    }
+
     /// An iterator visiting all faces.
     ///
     /// The first returned face is the outer face, all other faces will be inner faces.


### PR DESCRIPTION
The previous algorithm was susceptible to hang in an endless loop (see #98 and #107).

This new method should approach the target position reliably as it can reliably cross constraint edges that lie between it and the target vertex.