### PR TITLE
Fixes #113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.12.1] - 2024-09-09
+
+### Fix
+
+- Fixes #113. This could lead to rare crashes when calling `ConstrainedDelaunayTriangulation::add_constraint_and_split`
+
 ## [2.12.0] - 2024-08-13
 
 ### Fix
@@ -468,6 +474,8 @@ A lot has changed for the 1.0. release, only larger changes are shown.
 ## 0.1.0 - 2016-09-23
 
 Initial commit
+
+[2.12.1]: https://github.com/Stoeoef/spade/compare/v2.12.0...v2.12.1
 
 [2.12.0]: https://github.com/Stoeoef/spade/compare/v2.11.0...v2.12.0
 

--- a/src/delaunay_core/triangulation_ext.rs
+++ b/src/delaunay_core/triangulation_ext.rs
@@ -11,7 +11,7 @@ use crate::{HasPosition, InsertionError, PositionInTriangulation, Triangulation}
 
 use alloc::vec::Vec;
 
-impl<T> TriangulationExt for T where T: Triangulation + ?Sized {}
+impl<T> TriangulationExt for T where T: Triangulation {}
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Hash, Eq, PartialEq)]
 pub enum PositionWhenAllVerticesOnLine {


### PR DESCRIPTION
`ConflictRegionEnd::NewVertex` was renamed to `ConflictRegionEnd::ConstraintEdgeSplit`