### PR TITLE
Fix link syntax in docs for voronoi edges

### DIFF
--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -368,7 +368,7 @@ pub trait Triangulation: Default {
 
     /// An iterator visiting all directed voronoi edges.
     ///
-    /// The iterator type is (DirectedVoronoiEdge)[DirectedVoronoiEdge]
+    /// The iterator type is [DirectedVoronoiEdge]
     fn directed_voronoi_edges(
         &self,
     ) -> DirectedVoronoiEdgeIterator<
@@ -382,7 +382,7 @@ pub trait Triangulation: Default {
 
     /// An iterator visiting all undirected voronoi edges.
     ///
-    /// The iterator type is (UndirectedVoronoiEdge)[UndirectedVoronoiEdge]
+    /// The iterator type is [UndirectedVoronoiEdge]
     fn undirected_voronoi_edges(
         &self,
     ) -> UndirectedVoronoiEdgeIterator<


### PR DESCRIPTION
This just fixes a minor formatting issue I came across while reading the docs :)

![Screenshot of the issue](https://github.com/user-attachments/assets/8e14624e-f107-4d80-a752-7c8da98824ac)