### PR TITLE
Jump-and-Walk

### DIFF
--- a/benches/bulk_load_benchmark.rs
+++ b/benches/bulk_load_benchmark.rs
@@ -13,6 +13,8 @@ pub fn bulk_load_benchmark(c: &mut Criterion) {
         (LastUsedVertex, Uniform),
         (Hierarchy, Uniform),
         (Hierarchy, RandomWalk),
+        (JumpAndWalk, Uniform),
+        (JumpAndWalk, RandomWalk),
     ] {
         let config = CreationBenchConfig {
             creation_method: CreationMethod::BulkLoad,

--- a/benches/bulk_load_vs_incremental.rs
+++ b/benches/bulk_load_vs_incremental.rs
@@ -6,7 +6,7 @@ pub fn bulk_load_vs_incremental_benchmark(c: &mut Criterion) {
     {
         use CreationMethod::*;
         let mut group = c.benchmark_group("bulk vs incremental loading");
-        for creation_method in [BulkLoad, Incremental] {
+        for creation_method in [BulkLoad, Incremental, JumpAndWalk] {
             let config = CreationBenchConfig {
                 creation_method,
                 sample_size: SampleSize::SmallSampleSet,

--- a/benches/locate_benchmark.rs
+++ b/benches/locate_benchmark.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use criterion::{measurement::WallTime, BenchmarkGroup, Criterion};
 use rand::distributions::uniform::SampleUniform;
 use spade::{
-    DelaunayTriangulation, HierarchyHintGeneratorWithBranchFactor, HintGenerator, Point2, SpadeNum,
-    Triangulation,
+    DelaunayTriangulation, HierarchyHintGeneratorWithBranchFactor, HintGenerator,
+    JumpAndWalkHintGenerator, Point2, SpadeNum, Triangulation,
 };
 
 use crate::benchmark_utilities::{uniform_distribution, uniform_f64, SEED2};
@@ -55,6 +55,13 @@ pub fn locate_benchmark(c: &mut Criterion) {
             uniform_f64(),
         );
     }
+
+    single_locate_benchmark::<JumpAndWalkHintGenerator, _, _>(
+        &mut group,
+        "locate (jump and walk)".to_string(),
+        RANGE,
+        uniform_f64(),
+    );
 
     single_hierarchy::<2>(&mut group);
     single_hierarchy::<3>(&mut group);

--- a/src/delaunay_core/mod.rs
+++ b/src/delaunay_core/mod.rs
@@ -22,7 +22,7 @@ pub use triangulation_ext::{RemovalResult, TriangulationExt};
 pub use dcel::Dcel;
 pub use hint_generator::{
     HierarchyHintGenerator, HierarchyHintGeneratorWithBranchFactor, HintGenerator,
-    LastUsedVertexHintGenerator,
+    JumpAndWalkHintGenerator, LastUsedVertexHintGenerator,
 };
 
 pub use refinement::{AngleLimit, RefinementParameters, RefinementResult};

--- a/src/delaunay_core/triangulation_ext.rs
+++ b/src/delaunay_core/triangulation_ext.rs
@@ -217,7 +217,7 @@ pub trait TriangulationExt: Triangulation {
         point: Point2<<Self::Vertex as HasPosition>::Scalar>,
         hint: Option<FixedVertexHandle>,
     ) -> PositionInTriangulation {
-        let start = hint.unwrap_or_else(|| self.hint_generator().get_hint(point));
+        let start = hint.unwrap_or_else(|| self.hint_generator().get_hint(point, self));
         self.locate_with_hint_fixed_core(point, start)
     }
 

--- a/src/delaunay_triangulation.rs
+++ b/src/delaunay_triangulation.rs
@@ -297,7 +297,7 @@ where
             return None;
         }
 
-        let hint = self.hint_generator().get_hint(position);
+        let hint = self.hint_generator().get_hint(position, self);
         let hint = self.validate_vertex_handle(hint);
 
         let vertex = self.walk_to_nearest_neighbor(hint, position);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use crate::delaunay_core::math::{
 
 pub use delaunay_core::{
     AngleLimit, HierarchyHintGenerator, HierarchyHintGeneratorWithBranchFactor, HintGenerator,
-    LastUsedVertexHintGenerator, RefinementParameters, RefinementResult,
+    JumpAndWalkHintGenerator, LastUsedVertexHintGenerator, RefinementParameters, RefinementResult,
 };
 
 pub use crate::delaunay_core::interpolation::{Barycentric, NaturalNeighbor};

--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -403,7 +403,7 @@ pub trait Triangulation: Default {
         &self,
         point: Point2<<Self::Vertex as HasPosition>::Scalar>,
     ) -> PositionInTriangulation {
-        let hint = self.hint_generator().get_hint(point);
+        let hint = self.hint_generator().get_hint(point, self);
         self.locate_with_hint_option_core(point, Some(hint))
     }
 


### PR DESCRIPTION
This is just a proof-of-concept.

I was interested to see how the [Jump-and-Walk algorithm](https://en.m.wikipedia.org/wiki/Jump-and-Walk_algorithm) would compare to your existing methods of point location. It's meant to perform better with high density clusters of points, and doesn't need any pre-sorting or maintenance of data structures.

Understandably it's worse than bulk last-used because the vertices are sorted for bulk insertion.
<img width="988" alt="Screenshot 2025-01-22 at 12 25 21 pm" src="https://github.com/user-attachments/assets/462254e1-e613-4930-93c6-04499c13202b" />

It's consistently slower than the hierarchy for location, but requires no hierarchy management.
<img width="988" alt="Screenshot 2025-01-22 at 12 25 47 pm" src="https://github.com/user-attachments/assets/a82da0a6-d3eb-4160-8746-94953f5efb63" />

The jump sampling count could probably be optimised a bit (and it's meant to be random rather than stepped, but I wanted determinism). Although I don't currently think there's a clear enough advantage to pursue it further, I thought I'd share the results in case you're interested (feel free to close this).