### PR TITLE
 Fixes #116

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 base64 = "0.22.1"
 anyhow = "1.0.75"
 shapefile = "0.6.0"
+proptest = "1.5.0"
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
Implements a new algorithm for `add_constraint_and_split`.
 The new algorithm should reliably replace invalid split positions with known valid positions that are _close enough_ to the correct split. This seems to lead to good results in practice.

 Also, the split algorithm is now conceptually simpler and has less surface for hidden bugs.

 Implements a new proptest for checking for additional issues. The proptest needs to be run manually.